### PR TITLE
Add more commands for instances

### DIFF
--- a/zdb/src/main/java/io/zeebe/broker/exporter/stream/ExporterPosition.java
+++ b/zdb/src/main/java/io/zeebe/broker/exporter/stream/ExporterPosition.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.broker.exporter.stream;
 

--- a/zdb/src/main/java/io/zeebe/broker/exporter/stream/ExportersState.java
+++ b/zdb/src/main/java/io/zeebe/broker/exporter/stream/ExportersState.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.broker.exporter.stream;
 

--- a/zdb/src/main/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceLifecycle.java
+++ b/zdb/src/main/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceLifecycle.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.processing.bpmn;
 

--- a/zdb/src/main/java/io/zeebe/engine/processor/RecordValues.java
+++ b/zdb/src/main/java/io/zeebe/engine/processor/RecordValues.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.processor;
 

--- a/zdb/src/main/java/io/zeebe/engine/processor/TypedEventImpl.java
+++ b/zdb/src/main/java/io/zeebe/engine/processor/TypedEventImpl.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.processor;
 

--- a/zdb/src/main/java/io/zeebe/engine/processor/TypedEventRegistry.java
+++ b/zdb/src/main/java/io/zeebe/engine/processor/TypedEventRegistry.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.processor;
 

--- a/zdb/src/main/java/io/zeebe/engine/processor/TypedRecord.java
+++ b/zdb/src/main/java/io/zeebe/engine/processor/TypedRecord.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.processor;
 

--- a/zdb/src/main/java/io/zeebe/engine/processor/workflow/deployment/distribute/PendingDeploymentDistribution.java
+++ b/zdb/src/main/java/io/zeebe/engine/processor/workflow/deployment/distribute/PendingDeploymentDistribution.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.processor.workflow.deployment.distribute;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/LastProcessedPosition.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/LastProcessedPosition.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/LastProcessedPositionState.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/LastProcessedPositionState.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/ZbColumnFamilies.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/ZbColumnFamilies.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/ZeebeState.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/ZeebeState.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/deployment/PersistedWorkflow.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/deployment/PersistedWorkflow.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state.deployment;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/deployment/WorkflowState.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/deployment/WorkflowState.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state.deployment;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/instance/AwaitWorkflowInstanceResultMetadata.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/instance/AwaitWorkflowInstanceResultMetadata.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state.instance;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/instance/ElementInstance.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/instance/ElementInstance.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state.instance;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/instance/ElementInstanceState.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/instance/ElementInstanceState.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state.instance;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/instance/Incident.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/instance/Incident.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state.instance;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/instance/IndexedRecord.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/instance/IndexedRecord.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state.instance;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/instance/JobRecordValue.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/instance/JobRecordValue.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state.instance;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/instance/JobState.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/instance/JobState.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state.instance;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/instance/ParentScopeKey.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/instance/ParentScopeKey.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state.instance;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/instance/StoredRecord.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/instance/StoredRecord.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state.instance;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/instance/VariableInstance.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/instance/VariableInstance.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state.instance;
 

--- a/zdb/src/main/java/io/zeebe/engine/state/instance/VariablesState.java
+++ b/zdb/src/main/java/io/zeebe/engine/state/instance/VariablesState.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.engine.state.instance;
 

--- a/zdb/src/main/java/io/zeebe/zdb/BlacklistCommand.java
+++ b/zdb/src/main/java/io/zeebe/zdb/BlacklistCommand.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb;
 

--- a/zdb/src/main/java/io/zeebe/zdb/IncidentCommand.java
+++ b/zdb/src/main/java/io/zeebe/zdb/IncidentCommand.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb;
 

--- a/zdb/src/main/java/io/zeebe/zdb/InstanceCommand.java
+++ b/zdb/src/main/java/io/zeebe/zdb/InstanceCommand.java
@@ -7,8 +7,8 @@
  */
 package io.zeebe.zdb;
 
+import io.zeebe.zdb.impl.InstanceInspection;
 import io.zeebe.zdb.impl.PartitionState;
-import io.zeebe.zdb.impl.WorkflowInspection;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
@@ -19,10 +19,10 @@ import picocli.CommandLine.ScopeType;
 import picocli.CommandLine.Spec;
 
 @Command(
-    name = "workflow",
+    name = "instance",
     mixinStandardHelpOptions = true,
-    description = "Print's information about deployed workflow's")
-public class WorkflowCommand implements Callable<Integer> {
+    description = "Print's information about running instances")
+public class InstanceCommand implements Callable<Integer> {
 
   @Spec private CommandSpec spec;
 
@@ -40,30 +40,12 @@ public class WorkflowCommand implements Callable<Integer> {
     return 0;
   }
 
-  @Command(name = "list", description = "List all workflows")
-  public int list() {
-    final var partitionState = PartitionState.of(partitionPath);
-    final var outputLines = new WorkflowInspection().list(partitionState);
-    outputLines.forEach(System.out::println);
-    return 0;
-  }
-
-  @Command(name = "entity", description = "Show details about a workflow")
+  @Command(name = "entity", description = "Show details about an  workflow instance")
   public int entity(
-      @Parameters(paramLabel = "KEY", description = "The key of the workflow", arity = "1")
+      @Parameters(paramLabel = "KEY", description = "The key of the workflow instance", arity = "1")
           final long key) {
     final var partitionState = PartitionState.of(partitionPath);
-    final var output = new WorkflowInspection().entity(partitionState, key);
-    System.out.println(output);
-    return 0;
-  }
-
-  @Command(name = "instances", description = "Show all instances of a workflow")
-  public int instances(
-      @Parameters(paramLabel = "KEY", description = "The key of the workflow", arity = "1")
-          final long key) {
-    final var partitionState = PartitionState.of(partitionPath);
-    final var output = new WorkflowInspection().getInstancesOfWorkflow(partitionState, key);
+    final var output = new InstanceInspection().entity(partitionState, key);
     System.out.println(output);
     return 0;
   }

--- a/zdb/src/main/java/io/zeebe/zdb/LogCommand.java
+++ b/zdb/src/main/java/io/zeebe/zdb/LogCommand.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb;
 

--- a/zdb/src/main/java/io/zeebe/zdb/LogSearchCommand.java
+++ b/zdb/src/main/java/io/zeebe/zdb/LogSearchCommand.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb;
 

--- a/zdb/src/main/java/io/zeebe/zdb/StatusCommand.java
+++ b/zdb/src/main/java/io/zeebe/zdb/StatusCommand.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb;
 

--- a/zdb/src/main/java/io/zeebe/zdb/ZeebeDebugger.java
+++ b/zdb/src/main/java/io/zeebe/zdb/ZeebeDebugger.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb;
 
@@ -24,7 +24,8 @@ import picocli.CommandLine.RunLast;
       BlacklistCommand.class,
       IncidentCommand.class,
       WorkflowCommand.class,
-      LogCommand.class
+      LogCommand.class,
+      InstanceCommand.class
     })
 public class ZeebeDebugger implements Callable<Integer> {
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/ExporterInspection.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/ExporterInspection.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl;
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/IncidentInspection.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/IncidentInspection.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl;
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/PartitionState.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/PartitionState.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl;
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/StatusInspection.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/StatusInspection.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl;
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/WorkflowInspection.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/WorkflowInspection.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl;
 
@@ -13,9 +13,11 @@ import io.zeebe.db.ColumnFamily;
 import io.zeebe.db.impl.DbLong;
 import io.zeebe.engine.state.ZbColumnFamilies;
 import io.zeebe.engine.state.deployment.PersistedWorkflow;
+import io.zeebe.engine.state.instance.ElementInstance;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 
 public final class WorkflowInspection {
 
@@ -47,6 +49,34 @@ public final class WorkflowInspection {
                     bufferAsString(workflow.getResourceName()),
                     bufferAsString(workflow.getResource())))
         .orElse("No workflow found with key: " + key);
+  }
+
+  public List<Long> getInstancesOfWorkflow(final PartitionState partitionState, final long key) {
+    final DbLong elementInstanceKey = new DbLong();
+
+    final ElementInstance elementInstance = new ElementInstance();
+    final var elementInstanceColumnFamily =
+        partitionState
+            .getZeebeDb()
+            .createColumnFamily(
+                ZbColumnFamilies.ELEMENT_INSTANCE_KEY,
+                partitionState.getDbContext(),
+                elementInstanceKey,
+                elementInstance);
+
+    final AtomicLong workflowInstanceCounter = new AtomicLong(0);
+    final List<Long> workkflowInstances = new ArrayList<>();
+    elementInstanceColumnFamily.forEach(
+        ((dbLong, elementInstance1) -> {
+          final var parentKey = elementInstance1.getParentKey();
+          final var workflowKey = elementInstance1.getValue().getWorkflowKey();
+          if (parentKey == -1 && workflowKey == key) {
+            workflowInstanceCounter.incrementAndGet();
+            workkflowInstances.add(elementInstance1.getKey());
+          }
+        }));
+
+    return workkflowInstances;
   }
 
   private ColumnFamily<DbLong, PersistedWorkflow> getColumnFamily(

--- a/zdb/src/main/java/io/zeebe/zdb/impl/db/ReadOnlyColumnFamily.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/db/ReadOnlyColumnFamily.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl.db;
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/db/ReadOnlyContext.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/db/ReadOnlyContext.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl.db;
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/db/ReadOnlyDbFactory.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/db/ReadOnlyDbFactory.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl.db;
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/db/ZeebeReadOnlyDB.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/db/ZeebeReadOnlyDB.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl.db;
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/log/LogConsistencyCheck.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/log/LogConsistencyCheck.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl.log;
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/log/LogPrint.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/log/LogPrint.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl.log;
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/log/LogSearch.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/log/LogSearch.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl.log;
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/log/LogStatus.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/log/LogStatus.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl.log;
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/log/MetaStore.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/log/MetaStore.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl.log;
 

--- a/zdb/src/main/java/io/zeebe/zdb/impl/log/ZeebeLog.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/log/ZeebeLog.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.0. You may not use this file
- * except in compliance with the Zeebe Community License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.zeebe.zdb.impl.log;
 

--- a/zdb/zdb
+++ b/zdb/zdb
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-java -jar target/zdb-0.2.0-SNAPSHOT.jar $@
+java -jar target/zdb-0.4.0.jar $@


### PR DESCRIPTION
Add the following commands

`zdb workflow instances KEY`  : Shows all running instances of workflow with key KEY
`zdb instance entity KEY` : Show details of workflow instance with key KEY


Example:
```
 ./zdb workflow instances 2251799851551953 --path PATH
[2251799871087706, 2251799871088888, 2251799871090873, 2251799871092908, 2251799871095029]

./zdb instance entity 2251799871095029 --path PATH
Workflow instance:
BPMN process id: *****
Version: 2
WorkflowKey: 2251799851551953
WorkflowInstanceKey: 2251799871095029
ElementId: *****
BpmnElementType: PROCESS
ParentWorkflowInstanceKey: -1
 \
  |-Key: 2251799871095076
  |-ElementId: *****
  |-BpmnElementType: INTERMEDIATE_CATCH_EVENT
```


