### PR TITLE
Compact log for 0.26 and lower

### DIFF
--- a/zdb/src/main/java/io/zeebe/zdb/LogCommand.java
+++ b/zdb/src/main/java/io/zeebe/zdb/LogCommand.java
@@ -8,7 +8,6 @@
 package io.zeebe.zdb;
 
 import io.zeebe.zdb.impl.log.LogConsistencyCheck;
-import io.zeebe.zdb.impl.log.LogPrint;
 import io.zeebe.zdb.impl.log.LogStatus;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
@@ -21,7 +20,7 @@ import picocli.CommandLine.Spec;
 @Command(
     name = "log",
     mixinStandardHelpOptions = true,
-    subcommands = LogSearchCommand.class,
+    subcommands = {LogSearchCommand.class, LogPrintCommand.class},
     description = "Allows to inspect the log via sub commands")
 public class LogCommand implements Callable<Integer> {
 
@@ -38,13 +37,6 @@ public class LogCommand implements Callable<Integer> {
   @Command(name = "status", description = "Print's the status of the log")
   public int status() {
     final var output = new LogStatus().scan(partitionPath);
-    System.out.println(output);
-    return 0;
-  }
-
-  @Command(name = "print", description = "Print's the complete log to standard out")
-  public int print() {
-    final var output = new LogPrint().print(partitionPath);
     System.out.println(output);
     return 0;
   }

--- a/zdb/src/main/java/io/zeebe/zdb/LogPrintCommand.java
+++ b/zdb/src/main/java/io/zeebe/zdb/LogPrintCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.zdb;
+
+import io.zeebe.zdb.impl.log.LogPrint;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Visibility;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+
+@Command(name = "print", description = "Print's the complete log to standard out")
+public class LogPrintCommand implements Callable<Integer> {
+
+  @Spec private CommandSpec spec;
+
+  @Option(
+      names = {"-f", "--format"},
+      paramLabel = "[json, compact]",
+      description = "The output format",
+      defaultValue = "json",
+      showDefaultValue = Visibility.ALWAYS)
+  private Format format;
+
+  @Override
+  public Integer call() {
+    final Path logPath = spec.findOption("-p").getValue();
+    final var output = new LogPrint(format).print(logPath);
+    System.out.println(output);
+    return 0;
+  }
+
+  public enum Format {
+    JSON,
+    COMPACT;
+  }
+}

--- a/zdb/src/main/java/io/zeebe/zdb/ZeebeDebugger.java
+++ b/zdb/src/main/java/io/zeebe/zdb/ZeebeDebugger.java
@@ -44,7 +44,10 @@ public class ZeebeDebugger implements Callable<Integer> {
 
   public static void main(String[] args) {
     disableWarning();
-    cli = new CommandLine(new ZeebeDebugger()).setExecutionStrategy(new RunLast());
+    cli =
+        new CommandLine(new ZeebeDebugger())
+            .setExecutionStrategy(new RunLast())
+            .setCaseInsensitiveEnumValuesAllowed(true);
     final int exitcode = cli.execute(args);
     System.exit(exitcode);
   }

--- a/zdb/src/main/java/io/zeebe/zdb/impl/log/CompactRecordLogger.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/log/CompactRecordLogger.java
@@ -141,6 +141,11 @@ public class CompactRecordLogger {
   }
 
   public void log() {
+    final String bulkMessage = format();
+    LOG.info(bulkMessage);
+  }
+
+  public String format() {
     final var bulkMessage = new StringBuilder().append("Compact log representation:\n");
     bulkMessage
         .append("--------\n")
@@ -171,7 +176,7 @@ public class CompactRecordLogger {
                     .append(entry.getKey())
                     .append("\n"));
 
-    LOG.info(bulkMessage.toString());
+    return bulkMessage.toString();
   }
 
   private StringBuilder summarizeRecord(final Record<?> record) {
@@ -237,7 +242,8 @@ public class CompactRecordLogger {
 
     final var formattedProcessId =
         StringUtils.isEmpty(bpmnProcessId) ? "?" : formatId(bpmnProcessId);
-    final var formattedInstanceKey = workflowInstanceKey < 0 ? "?" : shortenKey(workflowInstanceKey);
+    final var formattedInstanceKey =
+        workflowInstanceKey < 0 ? "?" : shortenKey(workflowInstanceKey);
 
     return String.format(" in <process %s[%s]>", formattedProcessId, formattedInstanceKey);
   }
@@ -265,7 +271,8 @@ public class CompactRecordLogger {
       result
           .append(summarizeElementInformation(value.getElementId(), value.getElementInstanceKey()))
           .append(
-              summarizeWorkflowInformation(value.getBpmnProcessId(), value.getWorkflowInstanceKey()));
+              summarizeWorkflowInformation(
+                  value.getBpmnProcessId(), value.getWorkflowInstanceKey()));
     } else {
       result.append(shortenKey(record.getKey()));
     }
@@ -361,7 +368,7 @@ public class CompactRecordLogger {
         .append(" starting <process ")
         .append(formatId(value.getBpmnProcessId()))
         // variables don't exist on this record in 0.26
-        //.append(summarizeVariables(value.getVariables()))
+        // .append(summarizeVariables(value.getVariables()))
         .toString();
   }
 
@@ -372,9 +379,9 @@ public class CompactRecordLogger {
         new StringBuilder().append("\"").append(value.getMessageName()).append("\" ");
 
     // isInterrupting does not yet exist on this record in 0.26
-    //if (value.isInterrupting()) {
+    // if (value.isInterrupting()) {
     //  result.append("(inter.) ");
-    //}
+    // }
 
     if (!StringUtils.isEmpty(value.getCorrelationKey())) {
       result.append("correlationKey: ").append(value.getCorrelationKey()).append(" ");
@@ -387,7 +394,7 @@ public class CompactRecordLogger {
         .append(
             summarizeWorkflowInformation(value.getBpmnProcessId(), value.getWorkflowInstanceKey()))
         // variables don't exist on this record in 0.26
-        //.append(summarizeVariables(value.getVariables()));
+        // .append(summarizeVariables(value.getVariables()));
         .toString();
   }
 
@@ -419,9 +426,9 @@ public class CompactRecordLogger {
         new StringBuilder().append("\"").append(value.getMessageName()).append("\" ");
 
     // isInterrupting does not yet exist on this record in 0.26
-    //if (value.isInterrupting()) {
+    // if (value.isInterrupting()) {
     //  result.append("(inter.) ");
-    //}
+    // }
 
     if (!StringUtils.isEmpty(value.getCorrelationKey())) {
       result.append("correlationKey: ").append(value.getCorrelationKey()).append(" ");

--- a/zdb/src/main/java/io/zeebe/zdb/impl/log/CompactRecordLogger.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/log/CompactRecordLogger.java
@@ -48,6 +48,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated copied from zeebe-test-util - in future versions, that class should just be used
+ *     directly through a dependency on zeebe-test-util
+ */
+@Deprecated
 public class CompactRecordLogger {
 
   private static final Logger LOG = LoggerFactory.getLogger("io.zeebe.test");

--- a/zdb/src/main/java/io/zeebe/zdb/impl/log/CompactRecordLogger.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/log/CompactRecordLogger.java
@@ -1,0 +1,570 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.zdb.impl.log;
+
+import static java.util.Comparator.comparing;
+import static java.util.Map.entry;
+import static java.util.Map.ofEntries;
+import static org.apache.commons.lang3.StringUtils.leftPad;
+import static org.apache.commons.lang3.StringUtils.rightPad;
+
+import io.zeebe.protocol.Protocol;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.intent.IncidentIntent;
+import io.zeebe.protocol.record.intent.Intent;
+import io.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.zeebe.protocol.record.value.ErrorRecordValue;
+import io.zeebe.protocol.record.value.IncidentRecordValue;
+import io.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.zeebe.protocol.record.value.JobRecordValue;
+import io.zeebe.protocol.record.value.MessageRecordValue;
+import io.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
+import io.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.zeebe.protocol.record.value.TimerRecordValue;
+import io.zeebe.protocol.record.value.VariableRecordValue;
+import io.zeebe.protocol.record.value.deployment.DeployedProcess;
+import io.zeebe.protocol.record.value.deployment.DeploymentResource;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CompactRecordLogger {
+
+  private static final Logger LOG = LoggerFactory.getLogger("io.zeebe.test");
+  private static final String BLOCK_SEPARATOR = " - ";
+
+  private static final Map<String, String> ABBREVIATIONS =
+      ofEntries(
+          entry("PROCESS", "PROC"),
+          entry("INSTANCE", "INST"),
+          entry("MESSAGE", "MSG"),
+          entry("SUBSCRIPTION", "SUB"),
+          entry("SEQUENCE", "SEQ"),
+          entry("DISTRIBUTED", "DISTR"),
+          entry("VARIABLE", "VAR"),
+          entry("ELEMENT_", ""),
+          entry("_ELEMENT", ""));
+
+  private static final Map<RecordType, Character> RECORD_TYPE_ABBREVIATIONS =
+      ofEntries(
+          entry(RecordType.COMMAND, 'C'),
+          entry(RecordType.EVENT, 'E'),
+          entry(RecordType.COMMAND_REJECTION, 'R'));
+
+  private final Map<ValueType, Function<Record<?>, String>> valueLoggers = new HashMap<>();
+  private final int keyDigits;
+  private final int valueTypeChars;
+  private final int intentChars;
+  private final boolean singlePartition;
+  private final Map<Long, String> substitutions = new HashMap<>();
+  private final ArrayList<Record<?>> records;
+
+  {
+    valueLoggers.put(ValueType.DEPLOYMENT, this::summarizeDeployment);
+    valueLoggers.put(ValueType.INCIDENT, this::summarizeIncident);
+    valueLoggers.put(ValueType.JOB, this::summarizeJob);
+    valueLoggers.put(ValueType.JOB_BATCH, this::summarizeJobBatch);
+    valueLoggers.put(ValueType.MESSAGE, this::summarizeMessage);
+    valueLoggers.put(
+        ValueType.MESSAGE_START_EVENT_SUBSCRIPTION, this::summarizeMessageStartEventSubscription);
+    valueLoggers.put(ValueType.MESSAGE_SUBSCRIPTION, this::summarizeMessageSubscription);
+    valueLoggers.put(ValueType.PROCESS, this::summarizeProcess);
+    valueLoggers.put(ValueType.PROCESS_INSTANCE, this::summarizeProcessInstance);
+    valueLoggers.put(ValueType.PROCESS_INSTANCE_CREATION, this::summarizeProcessInstanceCreation);
+    valueLoggers.put(
+        ValueType.PROCESS_MESSAGE_SUBSCRIPTION, this::summarizeProcessInstanceSubscription);
+    valueLoggers.put(ValueType.VARIABLE, this::summarizeVariable);
+    valueLoggers.put(ValueType.TIMER, this::summarizeTimer);
+    valueLoggers.put(ValueType.ERROR, this::summarizeError);
+    // TODO please extend list
+  }
+
+  public CompactRecordLogger(final Collection<Record<?>> records) {
+    this.records = new ArrayList<>(records);
+
+    singlePartition =
+        this.records.stream()
+                .mapToLong(Record::getKey)
+                .filter(key -> key != -1)
+                .map(Protocol::decodePartitionId)
+                .distinct()
+                .count()
+            < 2;
+    final var highestPosition = this.records.get(this.records.size() - 1).getPosition();
+
+    int digits = 0;
+    long num = highestPosition;
+    while (num != 0) {
+      // num = num/10
+      num /= 10;
+      ++digits;
+    }
+
+    keyDigits = digits;
+
+    valueTypeChars =
+        this.records.stream()
+            .map(Record::getValueType)
+            .map(ValueType::name)
+            .map(this::abbreviate)
+            .mapToInt(String::length)
+            .max()
+            .orElse(0);
+
+    intentChars =
+        this.records.stream()
+            .map(Record::getIntent)
+            .map(Intent::name)
+            .map(this::abbreviate)
+            .mapToInt(String::length)
+            .max()
+            .orElse(0);
+  }
+
+  public void log() {
+    final var bulkMessage = new StringBuilder().append("Compact log representation:\n");
+    bulkMessage
+        .append("--------\n")
+        .append(
+            "\t['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]\n")
+        .append(
+            "\tP9K999 - key; #999 - record position; \"ID\" element/process id; @\"elementid\"/[P9K999] - element with ID and key\n")
+        .append(
+            "\tKeys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.\n")
+        .append(
+            "\tLong IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'\n")
+        .append("--------\n");
+
+    records.forEach(
+        record -> {
+          bulkMessage.append(summarizeRecord(record)).append("\n");
+        });
+
+    bulkMessage.append("--------\n").append("Decomposed keys (for debugging):\n");
+
+    substitutions.entrySet().stream()
+        .sorted(comparing(Entry::getValue))
+        .forEach(
+            entry ->
+                bulkMessage
+                    .append(entry.getValue())
+                    .append(" <-> ")
+                    .append(entry.getKey())
+                    .append("\n"));
+
+    LOG.info(bulkMessage.toString());
+  }
+
+  private StringBuilder summarizeRecord(final Record<?> record) {
+    final StringBuilder message = new StringBuilder();
+
+    message.append(summarizeIntent(record));
+    message.append(summarizePositionFields(record));
+    message.append(summarizeValue(record));
+
+    if (record.getRecordType() == RecordType.COMMAND_REJECTION) {
+      message.append(" ");
+      message.append(summarizeRejection(record));
+    }
+
+    return message;
+  }
+
+  private StringBuilder summarizePositionFields(final Record<?> record) {
+    return new StringBuilder()
+        .append(formatPosition(record.getPosition()))
+        .append("->")
+        .append(formatPosition(record.getSourceRecordPosition()))
+        .append(" ")
+        .append(shortenKey(record.getKey()))
+        .append(BLOCK_SEPARATOR);
+  }
+
+  private StringBuilder summarizeIntent(final Record<?> record) {
+    final var valueType = record.getValueType();
+
+    return new StringBuilder()
+        .append(RECORD_TYPE_ABBREVIATIONS.get(record.getRecordType()))
+        .append(" ")
+        .append(rightPad(abbreviate(valueType.name()), valueTypeChars))
+        .append(" ")
+        .append(rightPad(abbreviate(record.getIntent().name()), intentChars))
+        .append(BLOCK_SEPARATOR);
+  }
+
+  private String summarizeValue(final Record<?> record) {
+    return valueLoggers.getOrDefault(record.getValueType(), this::summarizeMiscValue).apply(record);
+  }
+
+  private String summarizeMiscValue(final Record<?> record) {
+    return record.getValue().getClass().getSimpleName() + " " + record.getValue().toJson();
+  }
+
+  private String summarizeDeployment(final Record<?> record) {
+    final var value = (DeploymentRecordValue) record.getValue();
+
+    return value.getResources().stream()
+        .map(DeploymentResource::getResourceName)
+        .collect(Collectors.joining());
+  }
+
+  private String summarizeElementInformation(
+      final String elementId, final long elementInstanceKey) {
+    return String.format(" @%s[%s]", formatId(elementId), shortenKey(elementInstanceKey));
+  }
+
+  private String summarizeProcessInformation(
+      final String bpmnProcessId, final long processInstanceKey) {
+
+    final var formattedProcessId =
+        StringUtils.isEmpty(bpmnProcessId) ? "?" : formatId(bpmnProcessId);
+    final var formattedInstanceKey = processInstanceKey < 0 ? "?" : shortenKey(processInstanceKey);
+
+    return String.format(" in <process %s[%s]>", formattedProcessId, formattedInstanceKey);
+  }
+
+  private String summarizeVariables(final Map<String, Object> variables) {
+    if (variables != null && !variables.isEmpty()) {
+      return " with variables: " + variables;
+    } else {
+      return " (no vars)";
+    }
+  }
+
+  private String summarizeIncident(final Record<?> record) {
+    final var value = (IncidentRecordValue) record.getValue();
+
+    final var result = new StringBuilder();
+
+    if (record.getIntent() != IncidentIntent.RESOLVE) {
+      result.append(value.getErrorType()).append(" ").append(value.getErrorMessage()).append(", ");
+
+      if (value.getJobKey() != -1) {
+        result.append("joBKey: ").append(shortenKey(value.getJobKey())).append(" ");
+      }
+
+      result
+          .append(summarizeElementInformation(value.getElementId(), value.getElementInstanceKey()))
+          .append(
+              summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()));
+    } else {
+      result.append(shortenKey(record.getKey()));
+    }
+    return result.toString();
+  }
+
+  private String summarizeJob(final Record<?> record) {
+    final var value = (JobRecordValue) record.getValue();
+
+    return summarizeJobRecordValue(record.getKey(), value);
+  }
+
+  private String summarizeJobRecordValue(final long jobKey, final JobRecordValue value) {
+    final var result = new StringBuilder();
+
+    if (jobKey != -1) {
+      result.append(shortenKey(jobKey));
+    }
+    if (!StringUtils.isEmpty(value.getType())) {
+      result
+          .append(" \"")
+          .append(value.getType())
+          .append("\"")
+          .append(summarizeElementInformation(value.getElementId(), value.getElementInstanceKey()));
+    }
+
+    result.append(" ").append(value.getRetries()).append(" retries,");
+
+    if (!StringUtils.isEmpty(value.getErrorCode())) {
+      result.append(" ").append(value.getErrorCode()).append(":").append(value.getErrorMessage());
+    }
+
+    result
+        .append(
+            summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()))
+        .append(summarizeVariables(value.getVariables()));
+
+    return result.toString();
+  }
+
+  private String summarizeJobBatch(final Record<?> record) {
+    final var value = (JobBatchRecordValue) record.getValue();
+    final var jobKeys = value.getJobKeys();
+
+    final var result = new StringBuilder();
+
+    result.append("\"").append(value.getType()).append("\" ");
+    if (jobKeys != null && !jobKeys.isEmpty()) {
+      result.append(jobKeys.size()).append("/").append(value.getMaxJobsToActivate());
+    } else {
+      result.append("max: ").append(value.getMaxJobsToActivate());
+    }
+
+    if (value.isTruncated()) {
+      result.append(" (truncated)");
+    }
+
+    if (jobKeys != null && !jobKeys.isEmpty()) {
+      for (int i = 0; i < jobKeys.size(); i++) {
+        final var jobKey = jobKeys.get(i);
+        final var job = value.getJobs().get(i);
+
+        result
+            .append(StringUtils.rightPad("\n", 8 + valueTypeChars))
+            .append(summarizeJobRecordValue(jobKey, job));
+      }
+    }
+
+    return result.toString();
+  }
+
+  private String summarizeMessage(final Record<?> record) {
+    final var value = (MessageRecordValue) record.getValue();
+
+    final var result = new StringBuilder().append("\"").append(value.getName()).append("\"");
+
+    if (!StringUtils.isEmpty(value.getCorrelationKey())) {
+      result.append(" correlationKey: ").append(value.getCorrelationKey());
+    }
+
+    result.append(summarizeVariables(value.getVariables()));
+
+    return result.toString();
+  }
+
+  private String summarizeMessageStartEventSubscription(final Record<?> record) {
+    final var value = (MessageStartEventSubscriptionRecordValue) record.getValue();
+
+    return new StringBuilder()
+        .append("\"")
+        .append(value.getMessageName())
+        .append("\"")
+        .append(" starting <process ")
+        .append(formatId(value.getBpmnProcessId()))
+        .append(summarizeVariables(value.getVariables()))
+        .toString();
+  }
+
+  private String summarizeMessageSubscription(final Record<?> record) {
+    final var value = (MessageSubscriptionRecordValue) record.getValue();
+
+    final var result =
+        new StringBuilder().append("\"").append(value.getMessageName()).append("\" ");
+
+    if (value.isInterrupting()) {
+      result.append("(inter.) ");
+    }
+
+    if (!StringUtils.isEmpty(value.getCorrelationKey())) {
+      result.append("correlationKey: ").append(value.getCorrelationKey()).append(" ");
+    }
+
+    result
+        .append("@[")
+        .append(shortenKey(value.getElementInstanceKey()))
+        .append("]")
+        .append(
+            summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()))
+        .append(summarizeVariables(value.getVariables()));
+    return result.toString();
+  }
+
+  private String summarizeProcess(final Record<?> record) {
+    final var value = (DeployedProcess) record.getValue();
+
+    return new StringBuilder()
+        .append(value.getResourceName())
+        .append("->")
+        .append(formatId(value.getBpmnProcessId()))
+        .append(" (version:")
+        .append(value.getVersion())
+        .append(")")
+        .toString();
+  }
+
+  private String summarizeProcessInstance(final Record<?> record) {
+    final var value = (ProcessInstanceRecordValue) record.getValue();
+    return new StringBuilder()
+        .append(value.getBpmnElementType())
+        .append(" ")
+        .append(formatId(value.getElementId()))
+        .append(
+            summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()))
+        .toString();
+  }
+
+  private String summarizeProcessInstanceCreation(final Record<?> record) {
+    final var value = (ProcessInstanceCreationRecordValue) record.getValue();
+    return new StringBuilder()
+        .append("new <process ")
+        .append(formatId(value.getBpmnProcessId()))
+        .append(">")
+        .append(summarizeVariables(value.getVariables()))
+        .toString();
+  }
+
+  private String summarizeProcessInstanceSubscription(final Record<?> record) {
+    final var value = (ProcessMessageSubscriptionRecordValue) record.getValue();
+
+    final var result =
+        new StringBuilder().append("\"").append(value.getMessageName()).append("\" ");
+
+    if (value.isInterrupting()) {
+      result.append("(inter.) ");
+    }
+
+    if (!StringUtils.isEmpty(value.getCorrelationKey())) {
+      result.append("correlationKey: ").append(value.getCorrelationKey()).append(" ");
+    }
+
+    result
+        .append("@[")
+        .append(shortenKey(value.getElementInstanceKey()))
+        .append("]")
+        .append(
+            summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()))
+        .append(summarizeVariables(value.getVariables()));
+
+    return result.toString();
+  }
+
+  private String summarizeVariable(final Record<?> record) {
+    final var value = (VariableRecordValue) record.getValue();
+
+    return new StringBuilder()
+        .append(value.getName())
+        .append("->")
+        .append(value.getValue())
+        .append(" in <process ")
+        .append("[")
+        .append(shortenKey(value.getProcessInstanceKey()))
+        .append("]>")
+        .toString();
+  }
+
+  private StringBuilder summarizeRejection(final Record<?> record) {
+    return new StringBuilder()
+        .append("!")
+        .append(record.getRejectionType())
+        .append(" (")
+        .append(StringUtils.abbreviate(record.getRejectionReason(), "..", 200))
+        .append(")");
+  }
+
+  private String summarizeTimer(final Record<?> record) {
+    final var value = (TimerRecordValue) record.getValue();
+    final var builder = new StringBuilder();
+    final var dueTime = Instant.ofEpochMilli(value.getDueDate()).atZone(ZoneId.systemDefault());
+
+    builder
+        .append(
+            summarizeElementInformation(value.getTargetElementId(), value.getElementInstanceKey()))
+        .append(" ")
+        .append(
+            summarizeProcessInformation(
+                shortenKey(value.getProcessDefinitionKey()), value.getProcessInstanceKey()))
+        .append(" due ")
+        .append(shortenDateTime(dueTime));
+
+    if (value.getRepetitions() > 1) {
+      builder.append(value.getRepetitions()).append(" reps");
+    }
+
+    return builder.toString();
+  }
+
+  private String summarizeError(final Record<?> record) {
+    final var value = (ErrorRecordValue) record.getValue();
+    return new StringBuilder()
+        .append("\"")
+        .append(value.getExceptionMessage())
+        .append("\"")
+        .append(" ")
+        .append(summarizeProcessInformation(null, value.getProcessInstanceKey()))
+        .append(" (")
+        .append(StringUtils.abbreviate(value.getStacktrace(), "..", 100))
+        .append(")")
+        .toString();
+  }
+
+  private String shortenKey(final long input) {
+    return substitutions.computeIfAbsent(input, this::formatKey);
+  }
+
+  private String formatKey(final long key) {
+    final var result = new StringBuilder();
+
+    if (!singlePartition) {
+      if (key > 0) {
+        result.append("P").append(Protocol.decodePartitionId(key));
+      } else {
+        result.append("  ");
+      }
+    }
+
+    if (key > 0) {
+      result.append(
+          "K" + leftPad(Long.toString(Protocol.decodeKeyInPartition(key)), keyDigits, '0'));
+    } else {
+      result.append(leftPad(Long.toString(key), keyDigits + 1, ' '));
+    }
+
+    return result.toString();
+  }
+
+  private String formatPosition(final long input) {
+    if (input >= 0) {
+      return "#" + leftPad(Long.toString(input), keyDigits, '0');
+    } else {
+      return leftPad(Long.toString(input), keyDigits + 1, ' ');
+    }
+  }
+
+  private String formatId(final String input) {
+    return "\"" + StringUtils.abbreviateMiddle(input, "..", 16) + "\"";
+  }
+
+  private String abbreviate(final String input) {
+    String result = input;
+
+    for (final String longForm : ABBREVIATIONS.keySet()) {
+      result = result.replace(longForm, ABBREVIATIONS.get(longForm));
+    }
+
+    return result;
+  }
+
+  // omit the date part if it's the same as right now
+  private String shortenDateTime(final ZonedDateTime time) {
+    final ZonedDateTime now = ZonedDateTime.now();
+    final StringBuilder builder = new StringBuilder();
+
+    if (!now.toLocalDate().isEqual(time.toLocalDate())) {
+      builder.append(DateTimeFormatter.ISO_LOCAL_DATE.format(time));
+    }
+
+    builder.append("T").append(DateTimeFormatter.ISO_LOCAL_TIME.format(time));
+    return builder.toString();
+  }
+}

--- a/zdb/src/main/java/io/zeebe/zdb/impl/log/LogPrint.java
+++ b/zdb/src/main/java/io/zeebe/zdb/impl/log/LogPrint.java
@@ -14,20 +14,32 @@ import io.atomix.storage.journal.index.JournalIndex;
 import io.atomix.storage.journal.index.Position;
 import io.zeebe.engine.processor.RecordValues;
 import io.zeebe.engine.processor.TypedEventImpl;
+import io.zeebe.engine.processor.TypedEventRegistry;
 import io.zeebe.logstreams.impl.log.LoggedEventImpl;
 import io.zeebe.logstreams.storage.atomix.ZeebeIndexAdapter;
 import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.util.ReflectUtil;
+import io.zeebe.zdb.LogPrintCommand.Format;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public class LogPrint {
+
+  private final Format format;
+
+  public LogPrint(final Format format) {
+    this.format = format;
+  }
 
   public String print(Path path) {
     final var zeebeLog = ZeebeLog.ofPath(path);
 
     final var startTime = System.currentTimeMillis();
     final var report = new StringBuilder("Scan log...").append(System.lineSeparator());
-    final var scanner = new LogPrint.Scanner(report);
+    final var scanner = new LogPrint.Scanner(report, format);
 
     // internally it scans the log
     zeebeLog.openLog(builder -> builder.withJournalIndexFactory(() -> scanner));
@@ -48,10 +60,13 @@ public class LogPrint {
     private final ZeebeIndexAdapter zeebeIndexAdapter;
     private final StringBuilder report;
     private int scannedEntries = 0;
+    private final Format format;
+    private List<Record<?>> records = new ArrayList<>();
 
-    Scanner(StringBuilder report) {
+    Scanner(StringBuilder report, final Format format) {
       this.zeebeIndexAdapter = ZeebeIndexAdapter.ofDensity(1);
       this.report = report;
+      this.format = format;
     }
 
     @Override
@@ -89,19 +104,32 @@ public class LogPrint {
 
     private void processEntry(final ZeebeEntry entry) {
       final var readBuffer = new UnsafeBuffer(entry.data());
-      final var loggedEvent = new LoggedEventImpl();
-      final var metadata = new RecordMetadata();
 
       int offset = 0;
       do {
+        final var loggedEvent = new LoggedEventImpl();
+        final var metadata = new RecordMetadata();
+
         loggedEvent.wrap(readBuffer, offset);
         loggedEvent.readMetadata(metadata);
 
         final var unifiedRecordValue =
-            RECORD_VALUES.readRecordValue(loggedEvent, metadata.getValueType());
+            ReflectUtil.newInstance(TypedEventRegistry.EVENT_REGISTRY.get(metadata.getValueType()));
+        loggedEvent.readValue(unifiedRecordValue);
+
         final var typedEvent = new TypedEventImpl(1);
         typedEvent.wrap(loggedEvent, metadata, unifiedRecordValue);
-        addToReport(typedEvent.toJson());
+
+        switch (format) {
+          case JSON:
+            addToReport(typedEvent.toJson());
+            break;
+          case COMPACT:
+            records.add(typedEvent);
+            break;
+          default:
+            throw new IllegalArgumentException("Unsupported format type " + format.name());
+        }
 
         offset += loggedEvent.getLength();
       } while (offset < readBuffer.capacity());
@@ -110,7 +138,14 @@ public class LogPrint {
     public String getReport() {
       report.append(System.lineSeparator()).append("Scanned entries: ").append(scannedEntries);
 
-      return report.toString();
+      switch (format) {
+        case JSON:
+          return report.toString();
+        case COMPACT:
+          return new CompactRecordLogger(records).format();
+        default:
+          throw new IllegalArgumentException("Unsupported format type " + format.name());
+      }
     }
   }
 }


### PR DESCRIPTION
This PR adds the CompactRecordLogger from zeebe-test-util. 

To make it compatible with the current zdb version, it had to be copied and changed to fit the 0.26 record value types. It also makes some changes on how the records are read, since the CompactRecordLogger requires an in-memory collection of all records it prints.

## Example

This PR adds the --format (or -f) option to `log print`, it's default is json
```
$ zdb log print
Missing required option: '--path=LOG_PATH'
Usage: zdb log print [-f=[json, compact]] -p=LOG_PATH
Print's the complete log to standard out
  -f, --format=[json, compact]
                        The output format
                          Default: json
  -p, --path=LOG_PATH   The path to the partition log data, should end with the
                          partition id.
```

It also has an option for `compact`. Choosing this results in a compacted output:

```
$ zdb log print -p ./data/raft-partition/partitions/1 -f compact
Compact log representation:
--------
	['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]
	P9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
	Keys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
	Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
--------
C DEPLOYMENT             CREATE         - #001->  -1   -1 - /Users/korthout/dev/camunda-cloud/data/workflow-2251799833995714.bpmn
E DEPLOYMENT             CREATED        - #002->#001 K002 - /Users/korthout/dev/camunda-cloud/data/workflow-2251799833995714.bpmn
C DEPLOYMENT             DISTRIBUTE     - #003->#002 K002 - /Users/korthout/dev/camunda-cloud/data/workflow-2251799833995714.bpmn
C MSG_START_EVENT_SUB    OPEN           - #004->#002   -1 - "DataAcquisitionDataAcquisitionCompleted" starting <process "CheckPr..reCheck"
E DEPLOYMENT             DISTR          - #005->#003 K002 - /Users/korthout/dev/camunda-cloud/data/workflow-2251799833995714.bpmn
E MSG_START_EVENT_SUB    OPENED         - #006->#004   -1 - "DataAcquisitionDataAcquisitionCompleted" starting <process "CheckPr..reCheck"
C MSG                    PUBLISH        - #007->  -1   -1 - "DataAcquisitionDataAcquisitionCompleted" correlationKey: 1 (no vars)
E MSG                    PUBLISHED      - #008->#007 K003 - "DataAcquisitionDataAcquisitionCompleted" correlationKey: 1 (no vars)
E WORKFLOW_INST          EVENT_OCCURRED - #009->#007 K006 - START_EVENT "StartEvent_1" in <process ?[K005]>
E WORKFLOW_INST          ACTIVATING     - #010->#009 K005 - PROCESS "CheckPr..reCheck" in <process "CheckPr..reCheck"[K005]>
E WORKFLOW_INST          ACTIVATED      - #011->#010 K005 - PROCESS "CheckPr..reCheck" in <process "CheckPr..reCheck"[K005]>
E WORKFLOW_INST          ACTIVATING     - #012->#011 K007 - START_EVENT "StartEvent_1" in <process "CheckPr..reCheck"[K005]>
E WORKFLOW_INST          ACTIVATED      - #013->#012 K007 - START_EVENT "StartEvent_1" in <process "CheckPr..reCheck"[K005]>
E WORKFLOW_INST          COMPLETING     - #014->#013 K007 - START_EVENT "StartEvent_1" in <process "CheckPr..reCheck"[K005]>
C INCIDENT               CREATE         - #015->#014   -1 - IO_MAPPING_ERROR failed to evaluate expression '{ticketNumber:orderNumber}': no variable found for name 'orderNumber',  @"StartEvent_1"[K007] in <process "CheckPr..reCheck"[K005]>
E INCIDENT               CREATED        - #016->#015 K008 - IO_MAPPING_ERROR failed to evaluate expression '{ticketNumber:orderNumber}': no variable found for name 'orderNumber',  @"StartEvent_1"[K007] in <process "CheckPr..reCheck"[K005]>
```