### PR TITLE
fix: donot reuse the objects for reading multiple records in batch

### DIFF
--- a/backend/src/main/kotlin/io/zell/zdb/log/LogContent.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogContent.kt
@@ -23,11 +23,12 @@ class LogContent {
                 val applicationEntry = entry.applicationEntry
 
                 val readBuffer = UnsafeBuffer(applicationEntry.data());
-                val loggedEvent = LoggedEventImpl();
-                val metadata = RecordMetadata();
 
                 var offset = 0;
                 do {
+                    val loggedEvent = LoggedEventImpl();
+                    val metadata = RecordMetadata();
+
                     loggedEvent.wrap(readBuffer, offset)
                     loggedEvent.readMetadata(metadata)
 


### PR DESCRIPTION
The data of records in a single batch was not displayed correctly. All records had same position for example. The other metadata were also wrong.