### PR TITLE
feat(cli): detect current path and make 'zdb' able to be run from any folder via PATH env var

### DIFF
--- a/cli/zdb
+++ b/cli/zdb
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
-java -jar target/zdb-*.jar $@
+DIR="$(dirname "$0")"
+JAR="$DIR/target/zdb-*.jar"
+
+java -jar "$JAR" $@

--- a/zdb
+++ b/zdb
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-java -jar zdb.jar $@
+DIR="$(dirname "$0")"
+JAR="$DIR/zdb.jar"
+
+java -jar "$JAR" $@


### PR DESCRIPTION
Hi,

thanks very much for this tool.
In our pipeline, I do bake it into the Zeebe broker images and realized,
when called from some folder via PATH env variable, an error occurs:
```
Error: Unable to access jarfile zdb.jar
``` 

This is a little fix, which assumes, ```zdb``` shell script and the ```zdb.jar``` file are next to each other.
Tested manually and works fine.