### PR TITLE
add key to incident details

### DIFF
--- a/backend/src/main/kotlin/io/zell/zdb/state/incident/IncidentDetails.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/state/incident/IncidentDetails.kt
@@ -7,7 +7,8 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 @Serializable
-class IncidentDetails private constructor(val bpmnProcessId : String,
+class IncidentDetails private constructor(val key : Long,
+                                          val bpmnProcessId : String,
                                           val processDefinitionKey : Long,
                                           val processInstanceKey : Long,
                                           val elementInstanceKey : Long,
@@ -17,8 +18,10 @@ class IncidentDetails private constructor(val bpmnProcessId : String,
                                           val errorType: ErrorType,
                                           val errorMessage : String) {
 
-    constructor(incident: IncidentRecord) :
-            this(incident.bpmnProcessId,
+    constructor(key: Long, incident: IncidentRecord) :
+            this(
+                key,
+                incident.bpmnProcessId,
                 incident.processDefinitionKey,
                 incident.processInstanceKey,
                 incident.elementInstanceKey,

--- a/backend/src/main/kotlin/io/zell/zdb/state/incident/IncidentState.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/state/incident/IncidentState.kt
@@ -31,7 +31,7 @@ class IncidentState(readonlyDb: ReadonlyTransactionDb) {
         val incidentState = zeebeDbState.incidentState
         val incidentRecord = incidentState.getIncidentRecord(incidentKey)
 
-        return IncidentDetails(incidentRecord)
+        return IncidentDetails(incidentKey, incidentRecord)
     }
 
     fun listIncidents(): List<IncidentDetails> {

--- a/backend/src/test/kotlin/ZeebeStateTest.java
+++ b/backend/src/test/kotlin/ZeebeStateTest.java
@@ -347,6 +347,7 @@ public class ZeebeStateTest {
 
     // then
     assertThat(incidentDetails).isNotNull();
+    assertThat(incidentDetails.getKey()).isEqualTo(incidentKey);
     assertThat(incidentDetails.getBpmnProcessId()).isEqualTo(returnedProcessInstance.getBpmnProcessId());
     assertThat(incidentDetails.getProcessDefinitionKey())
         .isEqualTo(returnedProcessInstance.getProcessDefinitionKey());
@@ -386,6 +387,7 @@ public class ZeebeStateTest {
 
     final var incidentDetails = incidents.get(0);
     assertThat(incidentDetails).isNotNull();
+    assertThat(incidentDetails.getKey()).isEqualTo(incidentKey);
     assertThat(incidentDetails.getBpmnProcessId()).isEqualTo(returnedProcessInstance.getBpmnProcessId());
     assertThat(incidentDetails.getProcessDefinitionKey())
         .isEqualTo(returnedProcessInstance.getProcessDefinitionKey());


### PR DESCRIPTION
The key of an incident is important information, especially for the list
command. Consider having some incident in the state which you're looking
up with zdb:

 zdb incident -p ./data/raft-partition/partitions/1/1runtime list | jq

Which then shows you all kinds of details about incidents, except the
key. However, the key is necessary to resolve the issue. So often you're
actually looking for that data.

Adding it is realatively easy, because in both the list and entity
command we already have the incident key available when we create the
details object.