### PR TITLE
Generate dot file format

### DIFF
--- a/backend/src/main/kotlin/io/zell/zdb/log/LogContent.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogContent.kt
@@ -56,9 +56,11 @@ class LogContent {
     }
 
     fun asDotFile(): String {
-        val content = StringBuilder("digraph log {\n")
+        val content = StringBuilder("digraph log {")
+            .append(System.lineSeparator())
             .append("rankdir=\"RL\"")
-            .append(";\n")
+            .append(";")
+            .append(System.lineSeparator())
 
         for (record in records) {
             if (record is ApplicationRecord) {
@@ -80,15 +82,22 @@ class LogContent {
 
                     content
                         .append("\\nKey: ").append(entry.key)
-                        .append("\"]").append(";\n")
+                        .append("\"]")
+                        .append(";")
+                        .append(System.lineSeparator())
                     if (entry.sourceRecordPosition != -1L) {
-                        content.append(entry.position).append(" -> ").append(entry.sourceRecordPosition).append(";\n")
+                        content.append(entry.position)
+                            .append(" -> ")
+                            .append(entry.sourceRecordPosition)
+                            .append(";")
+                            .append(System.lineSeparator())
                     }
 
                 }
             }
         }
-        content.append("\n}")
+        content.append(System.lineSeparator())
+            .append("}")
         return content.toString()
     }
 }

--- a/backend/src/main/kotlin/io/zell/zdb/log/LogContent.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogContent.kt
@@ -62,42 +62,46 @@ class LogContent {
             .append(";")
             .append(System.lineSeparator())
 
-        for (record in records) {
-            if (record is ApplicationRecord) {
-                for (entry in record.entries) {
-
-                    content.append(entry.position)
-                        .append(" [label=\"")
-                        .append("\\n").append(entry.recordType)
-                        .append("\\n").append(entry.valueType.name)
-                        .append("\\n").append(entry.intent.name())
-
-                    if (entry.valueType == ValueType.PROCESS_INSTANCE) {
-                        val processInstanceRecord = entry as TypedRecord<ProcessInstanceRecord>
-                        val processInstanceValue = processInstanceRecord.value
-                        content.append("\\n").append(processInstanceValue.bpmnElementType)
-                        content.append("\\nPI Key: ").append(processInstanceValue.processInstanceKey)
-                        content.append("\\nPD Key: ").append(processInstanceValue.processDefinitionKey)
-                    }
-
-                    content
-                        .append("\\nKey: ").append(entry.key)
-                        .append("\"]")
-                        .append(";")
-                        .append(System.lineSeparator())
-                    if (entry.sourceRecordPosition != -1L) {
-                        content.append(entry.position)
-                            .append(" -> ")
-                            .append(entry.sourceRecordPosition)
-                            .append(";")
-                            .append(System.lineSeparator())
-                    }
-
-                }
+        records
+            .filterIsInstance<ApplicationRecord>()
+            .flatMap { it.entries }
+            .forEach{
+                addEventAsDotNode(it, content)
             }
-        }
         content.append(System.lineSeparator())
             .append("}")
         return content.toString()
+    }
+
+    private fun addEventAsDotNode(
+        entry: TypedEventImpl,
+        content: java.lang.StringBuilder
+    ) {
+        content.append(entry.position)
+            .append(" [label=\"")
+            .append("\\n").append(entry.recordType)
+            .append("\\n").append(entry.valueType.name)
+            .append("\\n").append(entry.intent.name())
+
+        if (entry.valueType == ValueType.PROCESS_INSTANCE) {
+            val processInstanceRecord = entry as TypedRecord<ProcessInstanceRecord>
+            val processInstanceValue = processInstanceRecord.value
+            content.append("\\n").append(processInstanceValue.bpmnElementType)
+            content.append("\\nPI Key: ").append(processInstanceValue.processInstanceKey)
+            content.append("\\nPD Key: ").append(processInstanceValue.processDefinitionKey)
+        }
+
+        content
+            .append("\\nKey: ").append(entry.key)
+            .append("\"]")
+            .append(";")
+            .append(System.lineSeparator())
+        if (entry.sourceRecordPosition != -1L) {
+            content.append(entry.position)
+                .append(" -> ")
+                .append(entry.sourceRecordPosition)
+                .append(";")
+                .append(System.lineSeparator())
+        }
     }
 }

--- a/backend/src/main/kotlin/io/zell/zdb/log/LogContent.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogContent.kt
@@ -57,6 +57,8 @@ class LogContent {
 
     fun asDotFile(): String {
         val content = StringBuilder("digraph log {\n")
+            .append("rankdir=\"RL\"")
+            .append(";\n")
 
         for (record in records) {
             if (record is ApplicationRecord) {
@@ -64,20 +66,20 @@ class LogContent {
 
                     content.append(entry.position)
                         .append(" [label=\"")
-                        .append("\n").append(entry.recordType)
-                        .append("\n").append(entry.valueType.name)
-                        .append("\n").append(entry.intent.name())
+                        .append("\\n").append(entry.recordType)
+                        .append("\\n").append(entry.valueType.name)
+                        .append("\\n").append(entry.intent.name())
 
                     if (entry.valueType == ValueType.PROCESS_INSTANCE) {
                         val processInstanceRecord = entry as TypedRecord<ProcessInstanceRecord>
                         val processInstanceValue = processInstanceRecord.value
-                        content.append("\n").append(processInstanceValue.bpmnElementType)
-                        content.append("\nPI Key: ").append(processInstanceValue.processInstanceKey)
-                        content.append("\nPD Key: ").append(processInstanceValue.processDefinitionKey)
+                        content.append("\\n").append(processInstanceValue.bpmnElementType)
+                        content.append("\\nPI Key: ").append(processInstanceValue.processInstanceKey)
+                        content.append("\\nPD Key: ").append(processInstanceValue.processDefinitionKey)
                     }
 
                     content
-                        .append("\nKey: ").append(entry.key)
+                        .append("\\nKey: ").append(entry.key)
                         .append("\"]").append(";\n")
                     if (entry.sourceRecordPosition != -1L) {
                         content.append(entry.position).append(" -> ").append(entry.sourceRecordPosition).append(";\n")

--- a/backend/src/test/kotlin/ZeebeLogTest.java
+++ b/backend/src/test/kotlin/ZeebeLogTest.java
@@ -201,6 +201,19 @@ public class ZeebeLogTest {
     assertThat(jsonNode).isNotNull(); // is valid json
   }
 
+  @Test
+  public void shouldReturnLogContentAsDotFile() throws JsonProcessingException {
+    // given
+    final var logPath = ZeebePaths.Companion.getLogPath(tempDir, "1");
+    var logContentReader = new LogContentReader(logPath);
+    final var content = logContentReader.content();
+
+    // when
+    final var dotFileContent = content.asDotFile();
+
+    // then
+    assertThat(dotFileContent).startsWith("digraph log {").endsWith("}");
+  }
 
   @Test
   public void shouldContainNoDuplicatesInLogContent() throws JsonProcessingException {

--- a/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
+++ b/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
 import picocli.CommandLine.Spec;
 
 @Command(name = "print", description = "Print's the complete log to standard out")
@@ -19,11 +20,22 @@ public class LogPrintCommand implements Callable<Integer> {
 
   @Spec private CommandSpec spec;
 
+  @Option(
+      names = {"-d", "--dot"},
+      description = "Print's the complete log in dot format, which can be consumed by graphviz")
+  private boolean dotToggle;
+
   @Override
   public Integer call() {
     final Path partitionPath = spec.findOption("-p").getValue();
-    final var logContent = new LogContentReader(partitionPath).content();
-    System.out.println(logContent);
+    final var logContentReader = new LogContentReader(partitionPath);
+    final var logContent = logContentReader.content();
+    if (dotToggle) {
+      System.out.println(logContent.asDotFile());
+    } else {
+      System.out.println(logContent);
+    }
+
     return 0;
   }
 }

--- a/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
+++ b/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
@@ -18,19 +18,26 @@ import picocli.CommandLine.Spec;
 @Command(name = "print", description = "Print's the complete log to standard out")
 public class LogPrintCommand implements Callable<Integer> {
 
+  public enum Format {
+    JSON,
+    DOT,
+  }
+
   @Spec private CommandSpec spec;
 
   @Option(
-      names = {"-d", "--dot"},
-      description = "Print's the complete log in dot format, which can be consumed by graphviz")
-  private boolean dotToggle;
+      names = {"-f", "--format"},
+      description =
+          "Print's the complete log in the specified format, defaults to json. Possible values: [ ${COMPLETION-CANDIDATES} ]",
+      defaultValue = "JSON")
+  private Format format;
 
   @Override
   public Integer call() {
     final Path partitionPath = spec.findOption("-p").getValue();
     final var logContentReader = new LogContentReader(partitionPath);
     final var logContent = logContentReader.content();
-    if (dotToggle) {
+    if (format == Format.DOT) {
       System.out.println(logContent.asDotFile());
     } else {
       System.out.println(logContent);


### PR DESCRIPTION
Add support for dot file format on the log print command

```
    zdb log print [-d,--dot] -p
```

Resources:

 * https://graphviz.org/docs/layouts/dot/
 * https://graphviz.org/doc/info/command.html

**Example:**


From test generated:

<details>
<summary>test.dot</summary>
<pre>
digraph log {
rankdir="RL";
1 [label="\nCOMMAND\nDEPLOYMENT\nCREATE\nKey: -1"];
2 [label="\nEVENT\nPROCESS\nCREATED\nKey: 2251799813685249"];
2 -> 1;
3 [label="\nEVENT\nPROCESS\nCREATED\nKey: 2251799813685250"];
3 -> 1;
4 [label="\nEVENT\nDEPLOYMENT\nCREATED\nKey: 2251799813685251"];
4 -> 1;
5 [label="\nEVENT\nDEPLOYMENT\nFULLY_DISTRIBUTED\nKey: 2251799813685251"];
5 -> 1;
6 [label="\nCOMMAND\nPROCESS_INSTANCE_CREATION\nCREATE\nKey: -1"];
7 [label="\nEVENT\nVARIABLE\nCREATED\nKey: 2251799813685253"];
7 -> 6;
8 [label="\nEVENT\nVARIABLE\nCREATED\nKey: 2251799813685254"];
8 -> 6;
9 [label="\nEVENT\nVARIABLE\nCREATED\nKey: 2251799813685255"];
9 -> 6;
10 [label="\nCOMMAND\nPROCESS_INSTANCE\nACTIVATE_ELEMENT\nPROCESS\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685252"];
10 -> 6;
11 [label="\nEVENT\nPROCESS_INSTANCE_CREATION\nCREATED\nKey: 2251799813685256"];
11 -> 6;
12 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATING\nPROCESS\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685252"];
12 -> 10;
13 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATED\nPROCESS\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685252"];
13 -> 10;
14 [label="\nCOMMAND\nPROCESS_INSTANCE\nACTIVATE_ELEMENT\nSTART_EVENT\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: -1"];
14 -> 10;
15 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATING\nSTART_EVENT\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685257"];
15 -> 14;
16 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATED\nSTART_EVENT\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685257"];
16 -> 14;
17 [label="\nCOMMAND\nPROCESS_INSTANCE\nCOMPLETE_ELEMENT\nSTART_EVENT\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685257"];
17 -> 14;
18 [label="\nCOMMAND\nMESSAGE\nPUBLISH\nKey: -1"];
19 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_COMPLETING\nSTART_EVENT\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685257"];
19 -> 17;
20 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_COMPLETED\nSTART_EVENT\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685257"];
20 -> 17;
21 [label="\nEVENT\nPROCESS_INSTANCE\nSEQUENCE_FLOW_TAKEN\nSEQUENCE_FLOW\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685258"];
21 -> 17;
22 [label="\nCOMMAND\nPROCESS_INSTANCE\nACTIVATE_ELEMENT\nPARALLEL_GATEWAY\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685259"];
22 -> 17;
23 [label="\nEVENT\nMESSAGE\nPUBLISHED\nKey: 2251799813685260"];
23 -> 18;
24 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATING\nPARALLEL_GATEWAY\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685259"];
24 -> 22;
25 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATED\nPARALLEL_GATEWAY\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685259"];
25 -> 22;
26 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_COMPLETING\nPARALLEL_GATEWAY\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685259"];
26 -> 22;
27 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_COMPLETED\nPARALLEL_GATEWAY\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685259"];
27 -> 22;
28 [label="\nEVENT\nPROCESS_INSTANCE\nSEQUENCE_FLOW_TAKEN\nSEQUENCE_FLOW\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685261"];
28 -> 22;
29 [label="\nCOMMAND\nPROCESS_INSTANCE\nACTIVATE_ELEMENT\nSERVICE_TASK\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685262"];
29 -> 22;
30 [label="\nEVENT\nPROCESS_INSTANCE\nSEQUENCE_FLOW_TAKEN\nSEQUENCE_FLOW\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685263"];
30 -> 22;
31 [label="\nCOMMAND\nPROCESS_INSTANCE\nACTIVATE_ELEMENT\nSERVICE_TASK\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685264"];
31 -> 22;
32 [label="\nCOMMAND\nMESSAGE\nPUBLISH\nKey: -1"];
33 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATING\nSERVICE_TASK\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685262"];
33 -> 29;
34 [label="\nEVENT\nINCIDENT\nCREATED\nKey: 2251799813685265"];
34 -> 29;
35 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATING\nSERVICE_TASK\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685264"];
35 -> 31;
36 [label="\nEVENT\nJOB\nCREATED\nKey: 2251799813685266"];
36 -> 31;
37 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATED\nSERVICE_TASK\nPI Key: 2251799813685252\nPD Key: 2251799813685249\nKey: 2251799813685264"];
37 -> 31;
38 [label="\nEVENT\nMESSAGE\nPUBLISHED\nKey: 2251799813685267"];
38 -> 32;
39 [label="\nCOMMAND\nPROCESS_INSTANCE_CREATION\nCREATE_WITH_AWAITING_RESULT\nKey: -1"];
40 [label="\nCOMMAND\nPROCESS_INSTANCE\nACTIVATE_ELEMENT\nPROCESS\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685268"];
40 -> 39;
41 [label="\nEVENT\nPROCESS_INSTANCE_CREATION\nCREATED\nKey: 2251799813685269"];
41 -> 39;
42 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATING\nPROCESS\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685268"];
42 -> 40;
43 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATED\nPROCESS\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685268"];
43 -> 40;
44 [label="\nCOMMAND\nPROCESS_INSTANCE\nACTIVATE_ELEMENT\nSTART_EVENT\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: -1"];
44 -> 40;
45 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATING\nSTART_EVENT\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685270"];
45 -> 44;
46 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATED\nSTART_EVENT\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685270"];
46 -> 44;
47 [label="\nCOMMAND\nPROCESS_INSTANCE\nCOMPLETE_ELEMENT\nSTART_EVENT\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685270"];
47 -> 44;
48 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_COMPLETING\nSTART_EVENT\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685270"];
48 -> 47;
49 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_COMPLETED\nSTART_EVENT\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685270"];
49 -> 47;
50 [label="\nEVENT\nPROCESS_INSTANCE\nSEQUENCE_FLOW_TAKEN\nSEQUENCE_FLOW\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685271"];
50 -> 47;
51 [label="\nCOMMAND\nPROCESS_INSTANCE\nACTIVATE_ELEMENT\nEND_EVENT\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685272"];
51 -> 47;
52 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATING\nEND_EVENT\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685272"];
52 -> 51;
53 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_ACTIVATED\nEND_EVENT\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685272"];
53 -> 51;
54 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_COMPLETING\nEND_EVENT\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685272"];
54 -> 51;
55 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_COMPLETED\nEND_EVENT\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685272"];
55 -> 51;
56 [label="\nCOMMAND\nPROCESS_INSTANCE\nCOMPLETE_ELEMENT\nPROCESS\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685268"];
56 -> 51;
57 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_COMPLETING\nPROCESS\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685268"];
57 -> 56;
58 [label="\nEVENT\nPROCESS_INSTANCE\nELEMENT_COMPLETED\nPROCESS\nPI Key: 2251799813685268\nPD Key: 2251799813685250\nKey: 2251799813685268"];
58 -> 56;
59 [label="\nCOMMAND\nJOB_BATCH\nACTIVATE\nKey: -1"];
60 [label="\nEVENT\nJOB_BATCH\nACTIVATED\nKey: 2251799813685273"];
60 -> 59;

}
</pre>
</details>

Generate dot file via:
`zdb log print -d -p ~/playground/raft-partition/partitions/1/ > output.dot`

Generate svg
`dot -Tsvg -o test.svg test.dot`

![test](https://user-images.githubusercontent.com/2758593/156778874-1c1fb44a-e18c-4cac-b226-6052241ebdc8.svg)
