### PR TITLE
Handle missing value types gracefully

### DIFF
--- a/backend/src/main/kotlin/io/zell/zdb/log/LogContent.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogContent.kt
@@ -1,12 +1,12 @@
 package io.zell.zdb.log
 
 import io.atomix.raft.storage.log.IndexedRaftLogEntry
-import io.camunda.zeebe.engine.processing.streamprocessor.*
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedEventImpl
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord
 import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord
 import io.camunda.zeebe.protocol.record.ValueType
-import io.camunda.zeebe.util.ReflectUtil
 import org.agrona.concurrent.UnsafeBuffer
 
 class LogContent {
@@ -30,12 +30,7 @@ class LogContent {
                     loggedEvent.wrap(readBuffer, offset)
                     loggedEvent.readMetadata(metadata)
 
-                    val unifiedRecordValue =
-                        ReflectUtil.newInstance(TypedEventRegistry.EVENT_REGISTRY.get(metadata.getValueType()))
-                    loggedEvent.readValue(unifiedRecordValue)
-
-                    val typedEvent = TypedEventImpl(1)
-                    typedEvent.wrap(loggedEvent, metadata, unifiedRecordValue)
+                    val typedEvent = convertToTypedEvent(loggedEvent, metadata)
 
                     applicationRecord.entries.add(typedEvent)
 

--- a/backend/src/main/kotlin/io/zell/zdb/log/LogHelper.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogHelper.kt
@@ -1,0 +1,37 @@
+package io.zell.zdb.log
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedEventImpl
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedEventRegistry
+import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl
+import io.camunda.zeebe.protocol.Protocol
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata
+import io.camunda.zeebe.util.ReflectUtil
+
+
+/**
+ * Reads the given log event details and converts it to a TypedEvent, which can be further processed.
+ *
+ * Based on the value type the typed event is created. If the value type doesn't exist, e.g. if a new version
+ * is read by zdb then a TypedEvent without a record value is returned.
+ *
+ */
+fun convertToTypedEvent(
+    loggedEvent: LoggedEventImpl,
+    metadata: RecordMetadata
+): TypedEventImpl {
+    val typedEvent = TypedEventImpl(Protocol.decodePartitionId(loggedEvent.key))
+
+    val recordValueClass = TypedEventRegistry.EVENT_REGISTRY.get(metadata.getValueType())
+    if (recordValueClass == null) {
+        // it is likely that the value type is a new type, which is not yet supported by zdb
+        typedEvent.wrap(loggedEvent, metadata, null)
+        return typedEvent
+    }
+
+    val unifiedRecordValue =
+        ReflectUtil.newInstance(recordValueClass)
+    loggedEvent.readValue(unifiedRecordValue)
+
+    typedEvent.wrap(loggedEvent, metadata, unifiedRecordValue)
+    return typedEvent
+}

--- a/backend/src/main/kotlin/io/zell/zdb/log/LogSearch.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogSearch.kt
@@ -1,13 +1,9 @@
 package io.zell.zdb.log
 
-import io.atomix.raft.storage.log.IndexedRaftLogEntry
 import io.atomix.raft.storage.log.RaftLogReader
-import io.camunda.zeebe.engine.processing.streamprocessor.TypedEventImpl
-import io.camunda.zeebe.engine.processing.streamprocessor.TypedEventRegistry
 import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata
 import io.camunda.zeebe.protocol.record.Record
-import io.camunda.zeebe.util.ReflectUtil
 import org.agrona.concurrent.UnsafeBuffer
 import java.nio.file.Path
 
@@ -38,15 +34,8 @@ class LogSearch (logPath: Path) {
                     loggedEvent.wrap(readBuffer, offset)
 
                     if (loggedEvent.position == position) {
-
                         loggedEvent.readMetadata(metadata)
-                        val unifiedRecordValue =
-                            ReflectUtil.newInstance(TypedEventRegistry.EVENT_REGISTRY.get(metadata.getValueType()))
-                        loggedEvent.readValue(unifiedRecordValue)
-
-                        val typedEvent = TypedEventImpl(1)
-                        typedEvent.wrap(loggedEvent, metadata, unifiedRecordValue)
-                        return typedEvent
+                        return convertToTypedEvent(loggedEvent, metadata)
                     }
                     offset += loggedEvent.getLength();
                 } while (offset < readBuffer.capacity());

--- a/backend/src/test/kotlin/LogHelperTest.java
+++ b/backend/src/test/kotlin/LogHelperTest.java
@@ -1,0 +1,37 @@
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.dispatcher.impl.log.DataFrameDescriptor;
+import io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor;
+import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.zell.zdb.log.LogHelperKt;
+import org.agrona.ExpandableArrayBuffer;
+import org.junit.jupiter.api.Test;
+
+public class LogHelperTest {
+
+  @Test
+  public void shouldHandleUnknownValueTypes() {
+    // given
+    final var buffer = new ExpandableArrayBuffer();
+    final var key = Protocol.encodePartitionId(1, 2);
+    // would be nice if we could create such log entries easier...
+    LogEntryDescriptor.setKey(buffer, DataFrameDescriptor.messageOffset(0), key);
+    final var loggedEvent = new LoggedEventImpl();
+    loggedEvent.wrap(buffer, 0);
+    final var recordMetadata = new RecordMetadata();
+    recordMetadata.valueType(ValueType.SBE_UNKNOWN);
+
+    // when
+    final var typedEvent = LogHelperKt.convertToTypedEvent(loggedEvent, recordMetadata);
+
+    // then
+    assertThat(typedEvent).isNotNull();
+    assertThat(typedEvent.getValue()).isNull();
+    assertThat(typedEvent.getPartitionId()).isEqualTo(1);
+    assertThat(typedEvent.getKey()).isEqualTo(key);
+    assertThat(typedEvent.toJson()).isNotEmpty();
+  }
+}


### PR DESCRIPTION

If a value type is read, which is unknow we will return the TypedEvent without record value which allows us to still print the record itself (toJson handle this gracefully for us).

I added only one new unit test to handle the unknown value type situation, since it is more complex to have a full functionally logged event, and this is already tested implicit via the other integration tests.

related to https://github.com/Zelldon/zdb/issues/160