### PR TITLE
Investigate state more generically

### DIFF
--- a/backend/src/main/kotlin/io/zell/zdb/db/readonly/transaction/ReadonlyTransactionDb.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/db/readonly/transaction/ReadonlyTransactionDb.kt
@@ -8,7 +8,7 @@ import org.rocksdb.RocksDB
 import java.io.File
 import java.nio.file.Path
 
-class ReadonlyTransactionDb : ZeebeTransactionDb<ZbColumnFamilies> {
+public class ReadonlyTransactionDb : ZeebeTransactionDb<ZbColumnFamilies> {
 
     constructor(
         defaultHandle: ColumnFamilyHandle?,

--- a/backend/src/main/kotlin/io/zell/zdb/db/readonly/transaction/ZeebeTransactionDb.java
+++ b/backend/src/main/kotlin/io/zell/zdb/db/readonly/transaction/ZeebeTransactionDb.java
@@ -38,7 +38,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
   private static final Logger LOG = Loggers.DB_LOGGER;
   private static final String ERROR_MESSAGE_CLOSE_RESOURCE =
       "Expected to close RocksDB resource successfully, but exception was thrown. Will continue to close remaining resources.";
-  private final RocksDB rocksDB;
+  public final RocksDB rocksDB;
   private final List<AutoCloseable> closables;
   private final ReadOptions prefixReadOptions;
   private final ReadOptions defaultReadOptions;
@@ -80,7 +80,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
     return prefixReadOptions;
   }
 
-  protected ColumnFamilyHandle getDefaultHandle() {
+  public ColumnFamilyHandle getDefaultHandle() {
     return defaultHandle;
   }
 

--- a/backend/src/main/kotlin/io/zell/zdb/state/Experimental.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/state/Experimental.kt
@@ -2,6 +2,8 @@ package io.zell.zdb.state
 
 import io.camunda.zeebe.db.impl.ZeebeDbConstants
 import io.camunda.zeebe.engine.state.ZbColumnFamilies
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.agrona.concurrent.UnsafeBuffer
 import org.rocksdb.OptimisticTransactionDB
 import org.rocksdb.ReadOptions
@@ -40,5 +42,10 @@ class Experimental(private var rocksDb: RocksDB) {
             countMap[cf] = count + 1
         }
         return countMap
+    }
+
+    fun stateStatisticsAsJsonString() : String {
+        val stateStatistics = stateStatistics()
+        return Json.encodeToString(stateStatistics)
     }
 }

--- a/backend/src/main/kotlin/io/zell/zdb/state/Experimental.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/state/Experimental.kt
@@ -1,0 +1,44 @@
+package io.zell.zdb.state
+
+import io.camunda.zeebe.db.impl.ZeebeDbConstants
+import io.camunda.zeebe.engine.state.ZbColumnFamilies
+import org.agrona.concurrent.UnsafeBuffer
+import org.rocksdb.OptimisticTransactionDB
+import org.rocksdb.ReadOptions
+import org.rocksdb.RocksDB
+import java.nio.file.Path
+import java.util.EnumMap
+import java.util.function.Function
+
+class Experimental(private var rocksDb: RocksDB) {
+        constructor(statePath: Path) : this(OptimisticTransactionDB.openReadOnly(statePath.toString()))
+
+
+    fun interface Visitor {
+        fun visit(cf: ZbColumnFamilies, key: ByteArray, value: ByteArray)
+    }
+    fun visitDB(visitor: Visitor) {
+       rocksDb.newIterator(rocksDb.defaultColumnFamily, ReadOptions()).use {
+           it.seekToFirst()
+           while (it.isValid) {
+               val key: ByteArray = it.key()
+               val value: ByteArray = it.value()
+               val unsafeBuffer = UnsafeBuffer(key)
+               val enumValue = unsafeBuffer.getLong(0, ZeebeDbConstants.ZB_DB_BYTE_ORDER)
+               val cf = ZbColumnFamilies.values()[enumValue.toInt()]
+               visitor.visit(cf, key, value)
+               it.next()
+           }
+       }
+    }
+
+    fun stateStatistics() : Map<ZbColumnFamilies, Int> {
+        val countMap = EnumMap<ZbColumnFamilies, Int>(ZbColumnFamilies::class.java)
+
+        visitDB { cf, _, _ ->
+            val count: Int = countMap.computeIfAbsent(cf) { 0 }
+            countMap[cf] = count + 1
+        }
+        return countMap
+    }
+}

--- a/backend/src/test/kotlin/ZeebeStateTest.java
+++ b/backend/src/test/kotlin/ZeebeStateTest.java
@@ -1,14 +1,9 @@
-import static io.camunda.zeebe.util.buffer.BufferUtil.startsWith;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
-import io.camunda.zeebe.client.api.worker.JobWorker;
-import io.camunda.zeebe.db.impl.ZeebeDbConstants;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
-import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -17,9 +12,7 @@ import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.FileUtil;
 import io.zeebe.containers.ZeebeContainer;
 import io.zell.zdb.ZeebePaths;
-import io.zell.zdb.db.readonly.transaction.ReadonlyTransactionDb;
-import io.zell.zdb.db.readonly.transaction.RocksDbInternal;
-import io.zell.zdb.db.readonly.transaction.ZeebeTransactionDb;
+import io.zell.zdb.state.Experimental;
 import io.zell.zdb.state.blacklist.BlacklistState;
 import io.zell.zdb.state.general.GeneralState;
 import io.zell.zdb.state.incident.IncidentState;
@@ -28,21 +21,14 @@ import io.zell.zdb.state.instance.InstanceState;
 import io.zell.zdb.state.process.ProcessState;
 import java.io.File;
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.ReadOptions;
-import org.rocksdb.RocksDB;
-import org.rocksdb.RocksIterator;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -121,30 +107,33 @@ public class ZeebeStateTest {
   }
 
   @Test
+  public void shouldCreateStatsForCompleteState() {
+    // given
+    final var experimental = new Experimental(ZeebePaths.Companion.getRuntimePath(tempDir, "1"));
+
+    // when
+    final var cfMap = experimental.stateStatistics();
+
+    // then
+    assertThat(cfMap).containsEntry(ZbColumnFamilies.JOBS, 1)
+            .containsEntry(ZbColumnFamilies.VARIABLES, 3)
+            .containsEntry(ZbColumnFamilies.INCIDENTS, 1)
+            .containsEntry(ZbColumnFamilies.ELEMENT_INSTANCE_KEY, 3);
+  }
+
+  @Test
   public void shouldListProcesses() {
     // given
 
-    var readonlyDb = ReadonlyTransactionDb.Companion.openReadonlyDb(ZeebePaths.Companion.getRuntimePath(tempDir, "1"));
-    RocksDB rocksDB = readonlyDb.rocksDB;
+    Experimental experimental = new Experimental(ZeebePaths.Companion.getRuntimePath(tempDir, "1"));
 
-    try (final RocksIterator iterator = rocksDB.newIterator(rocksDB.getDefaultColumnFamily(), new ReadOptions())) {
-      iterator.seekToFirst();
-      for (;
-           iterator.isValid();
-           iterator.next()) {
-        final byte[] key = iterator.key();
-        byte[] value = iterator.value();
+    experimental.visitDB(((cf, key, value) ->
+    {
 
-        UnsafeBuffer unsafeBuffer = new UnsafeBuffer(key);
-        long enumValue = unsafeBuffer.getLong(0, ZeebeDbConstants.ZB_DB_BYTE_ORDER);
-        var cf = ZbColumnFamilies.values()[(int) enumValue];
-
-        System.out.printf("\nColumnFamily?: '%s'", cf);
-        System.out.printf("\nKey: '%s'", new String(key));
-        System.out.printf("\nValue: '%s'", new String(value));
-      }
-    }
-
+      System.out.printf("\nColumnFamily?: '%s'", cf);
+      System.out.printf("\nKey: '%s'", new String(key));
+      System.out.printf("\nValue: '%s'", new String(value));
+    }));
   }
 
   @Test

--- a/backend/src/test/kotlin/ZeebeStateTest.java
+++ b/backend/src/test/kotlin/ZeebeStateTest.java
@@ -21,6 +21,7 @@ import io.zell.zdb.state.instance.InstanceState;
 import io.zell.zdb.state.process.ProcessState;
 import java.io.File;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
@@ -119,6 +120,24 @@ public class ZeebeStateTest {
             .containsEntry(ZbColumnFamilies.VARIABLES, 3)
             .containsEntry(ZbColumnFamilies.INCIDENTS, 1)
             .containsEntry(ZbColumnFamilies.ELEMENT_INSTANCE_KEY, 3);
+  }
+
+  @Test
+  public void shouldVisitValuesAsJson() {
+    // given
+    final var experimental = new Experimental(ZeebePaths.Companion.getRuntimePath(tempDir, "1"));
+    final var incidentMap = new HashMap<String, String>();
+    Experimental.JsonVisitor jsonVisitor = (cf, k, v) -> {
+      if (cf == ZbColumnFamilies.INCIDENTS) {
+        incidentMap.put(new String(k), v);
+      }
+    };
+
+    // when
+    experimental.visitDBWithJsonValues(jsonVisitor);
+
+    // then
+    assertThat(incidentMap).containsValue("{\"incidentRecord\":{\"errorType\":\"IO_MAPPING_ERROR\",\"errorMessage\":\"failed to evaluate expression '{bar:foo}': no variable found for name 'foo'\",\"bpmnProcessId\":\"process\",\"processDefinitionKey\":2251799813685249,\"processInstanceKey\":2251799813685251,\"elementId\":\"incidentTask\",\"elementInstanceKey\":2251799813685261,\"jobKey\":-1,\"variableScopeKey\":2251799813685261}}");
   }
 
   @Test

--- a/cli/src/main/java/io/zell/zdb/StateCommand.java
+++ b/cli/src/main/java/io/zell/zdb/StateCommand.java
@@ -41,10 +41,22 @@ public class StateCommand implements Callable<Integer> {
 
   /** Alpha feature: Planned to replace old specific status calls */
   @Command(name = "list", description = "List column families and the values as json")
-  public int list() {
+  public int list(
+      @Option(
+              names = {"-cf", "--columnFamily"},
+              paramLabel = "COLUMNFAMILY",
+              description = "The column family name to filter for")
+          final String columnFamilyName) {
+    System.out.print("ColumnFamily,Key,Value");
     final var experimental = new Experimental(partitionPath);
     experimental.visitDBWithJsonValues(
-        ((cf, key, valueJson) -> System.out.printf("%s,%s,%s", cf, new String(key), valueJson)));
+        ((cf, key, valueJson) -> {
+          if (columnFamilyName == null
+              || columnFamilyName.isEmpty()
+              || cf.toString().equals(columnFamilyName)) {
+            System.out.printf("\n%s,%s,%s", cf, new String(key), valueJson);
+          }
+        }));
     return 0;
   }
 }

--- a/cli/src/main/java/io/zell/zdb/StateCommand.java
+++ b/cli/src/main/java/io/zell/zdb/StateCommand.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zell.zdb;
+
+import io.zell.zdb.state.Experimental;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+// THIS IS IN ALPHA STATE
+@Command(
+    name = "state",
+    mixinStandardHelpOptions = true,
+    description = "Prints general information of the internal state")
+public class StateCommand implements Callable<Integer> {
+
+  @Option(
+      names = {"-p", "--path"},
+      paramLabel = "PARTITION_PATH",
+      description = "The path to the partition data (either runtime or snapshot in partition dir)",
+      required = true)
+  private Path partitionPath;
+
+  /**
+   * Alpha feature: Planned to replace old status call
+   *
+   * @return the status code of the call
+   */
+  @Override
+  public Integer call() {
+    final var jsonString = new Experimental(partitionPath).stateStatisticsAsJsonString();
+    System.out.println(jsonString);
+    return 0;
+  }
+
+  /** Alpha feature: Planned to replace old specific status calls */
+  @Command(name = "list", description = "List column families and the values as json")
+  public int list() {
+    final var experimental = new Experimental(partitionPath);
+    experimental.visitDBWithJsonValues(
+        ((cf, key, valueJson) -> System.out.printf("%s,%s,%s", cf, new String(key), valueJson)));
+    return 0;
+  }
+}

--- a/cli/src/main/java/io/zell/zdb/StatusCommand.java
+++ b/cli/src/main/java/io/zell/zdb/StatusCommand.java
@@ -7,6 +7,7 @@
  */
 package io.zell.zdb;
 
+import io.zell.zdb.state.Experimental;
 import io.zell.zdb.state.general.GeneralState;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
@@ -30,6 +31,18 @@ public class StatusCommand implements Callable<Integer> {
   public Integer call() {
     final var generalDetails = new GeneralState(partitionPath).generalDetails();
     System.out.println(generalDetails);
+    return 0;
+  }
+
+  /**
+   * Alpha feature: Planned to replace old status call
+   *
+   * @return the status code of the call
+   */
+  @Command(name = "details", description = "Print for all column families the detailed statistics")
+  public int list() {
+    final var jsonString = new Experimental(partitionPath).stateStatisticsAsJsonString();
+    System.out.println(jsonString);
     return 0;
   }
 }

--- a/cli/src/main/java/io/zell/zdb/ZeebeDebugger.java
+++ b/cli/src/main/java/io/zell/zdb/ZeebeDebugger.java
@@ -27,7 +27,8 @@ import picocli.CommandLine.RunLast;
       IncidentCommand.class,
       ProcessCommand.class,
       LogCommand.class,
-      InstanceCommand.class
+      InstanceCommand.class,
+      StateCommand.class
     })
 public class ZeebeDebugger implements Callable<Integer> {
   private static CommandLine cli;


### PR DESCRIPTION
To not always fix zdb on new Zeebe version, since state classes have changed etc. I would like to implemented the state view in a more generic way. 

This is my first attempt, can be seen as alpha version. It allows to iterate over the complete state, you can use it to print statistics like:

```
$ time java -jar cli/target/cli-1.6.0-SNAPSHOT-jar-with-dependencies.jar status -p /home/cqjawa/incident/2023-01-03/1/snapshots/801194-2-3258598-3298276 details | jq
{
  "DEFAULT": 1,
  "KEY": 1,
  "PROCESS_VERSION": 1,
  "PROCESS_CACHE": 5,
  "PROCESS_CACHE_BY_ID_AND_VERSION": 5,
  "PROCESS_CACHE_DIGEST_BY_ID": 1,
  "ELEMENT_INSTANCE_PARENT_CHILD": 73333,
  "ELEMENT_INSTANCE_KEY": 73333,
  "NUMBER_OF_TAKEN_SEQUENCE_FLOWS": 2,
  "ELEMENT_INSTANCE_CHILD_PARENT": 73333,
  "VARIABLES": 4,
  "JOBS": 70456,
  "JOB_STATES": 70456,
  "JOB_ACTIVATABLE": 70456,
  "INCIDENTS": 1298,
  "INCIDENT_PROCESS_INSTANCES": 1298,
  "EVENT_SCOPE": 70456,
  "EXPORTER": 2
}

real	0m0.561s
user	0m0.785s
sys	0m0.134s
```

This can be further filtered with `jq`:

```
$ java -jar cli/target/cli-1.6.0-SNAPSHOT-jar-with-dependencies.jar state -p /home/cqjawa/incident/2023-01-03/1/snapshots/801194-2-3258598-3298276 | jq '.INCIDENTS'
1298
```

But you can also print the complete state where the values are tried to convert to json, if possible. The print of the complete state might be a big amount of data, which is why it can be filtered by column family name.

Example:

```
$ java -jar cli/target/cli-1.6.0-SNAPSHOT-jar-with-dependencies.jar state -p /home/cqjawa/incident/2023-01-03/1/snapshots/801194-2-3258598-3298276 list -cf INCIDENTS

ColumnFamily,Key,Value
INCIDENTS,^@^@^@^@^@^@^@"^@^H^@^@^@^@^Vs,{"incidentRecord":{"errorType":"EXTRACT_VALUE_ERROR","errorMessage":"failed to evaluate expression 'review': no variable found for name 'review'","bpmnProcessId":"Process_372fbfc7-9a4a-4f0b-aee5-bd96ed3e3e5d","processDefinitionKey":2251799813686656,"processInstanceKey":2251799813686738,"elementId":"Gateway_0bflorp","elementInstanceKey":2251799813690988,"jobKey":-1,"variableScopeKey":2251799813690988}}
```

For now the output is more cv style, due to lack of time. Likely it might be converted to complete json. _See it as an alpha feature._

The printing of state is done incrementally, in order to avoid OOM on bigger states.

related to https://github.com/Zelldon/zdb/issues/171