### PR TITLE
feat: print valid json

### DIFF
--- a/backend/src/main/kotlin/io/zell/zdb/state/Experimental.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/state/Experimental.kt
@@ -10,6 +10,7 @@ import org.agrona.concurrent.UnsafeBuffer
 import org.rocksdb.OptimisticTransactionDB
 import org.rocksdb.ReadOptions
 import org.rocksdb.RocksDB
+import java.nio.ByteOrder
 import java.nio.file.Path
 import java.util.EnumMap
 import java.util.function.Function

--- a/backend/src/test/kotlin/ZeebeStateTest.java
+++ b/backend/src/test/kotlin/ZeebeStateTest.java
@@ -137,7 +137,7 @@ public class ZeebeStateTest {
     experimental.visitDBWithJsonValues(jsonVisitor);
 
     // then
-    assertThat(incidentMap).containsValue("{\"incidentRecord\":{\"errorType\":\"IO_MAPPING_ERROR\",\"errorMessage\":\"failed to evaluate expression '{bar:foo}': no variable found for name 'foo'\",\"bpmnProcessId\":\"process\",\"processDefinitionKey\":2251799813685249,\"processInstanceKey\":2251799813685251,\"elementId\":\"incidentTask\",\"elementInstanceKey\":2251799813685261,\"jobKey\":-1,\"variableScopeKey\":2251799813685261}}");
+    assertThat(incidentMap).containsValue("{\"incidentRecord\":{\"errorType\":\"IO_MAPPING_ERROR\",\"errorMessage\":\"failed to evaluate expression '{bar:foo}': no variable found for name 'foo'\",\"bpmnProcessId\":\"process\",\"processDefinitionKey\":2251799813685249,\"processInstanceKey\":2251799813685251,\"elementId\":\"incidentTask\",\"elementInstanceKey\":2251799813685262,\"jobKey\":-1,\"variableScopeKey\":2251799813685262}}");
   }
 
   @Test

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -270,6 +270,14 @@
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>17</source>
+                <target>17</target>
+            </configuration>
+        </plugin>
 
     </plugins>
   </build>

--- a/cli/src/main/java/io/zell/zdb/StateCommand.java
+++ b/cli/src/main/java/io/zell/zdb/StateCommand.java
@@ -7,6 +7,7 @@
  */
 package io.zell.zdb;
 
+import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 import io.zell.zdb.state.Experimental;
 import java.nio.file.Path;
 import java.util.HexFormat;
@@ -55,9 +56,8 @@ public class StateCommand implements Callable<Integer> {
     final var counter = new AtomicInteger(0);
     experimental.visitDBWithJsonValues(
         ((cf, key, valueJson) -> {
-          if (columnFamilyName == null
-              || columnFamilyName.isEmpty()
-              || cf.toString().equals(columnFamilyName)) {
+          if (noColumnFamilyGiven(columnFamilyName)
+              || isMatchingColumnFamily(columnFamilyName, cf)) {
             if (counter.getAndIncrement() >= 1) {
               System.out.print(',');
             }
@@ -68,5 +68,14 @@ public class StateCommand implements Callable<Integer> {
         }));
     System.out.print("]}");
     return 0;
+  }
+
+  private static boolean isMatchingColumnFamily(String columnFamilyName, ZbColumnFamilies cf) {
+    return cf.toString().equalsIgnoreCase(columnFamilyName);
+  }
+
+  private static boolean noColumnFamilyGiven(String columnFamilyName) {
+    return columnFamilyName == null
+            || columnFamilyName.isEmpty();
   }
 }

--- a/cli/src/main/java/io/zell/zdb/StateCommand.java
+++ b/cli/src/main/java/io/zell/zdb/StateCommand.java
@@ -9,7 +9,9 @@ package io.zell.zdb;
 
 import io.zell.zdb.state.Experimental;
 import java.nio.file.Path;
+import java.util.HexFormat;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -47,16 +49,23 @@ public class StateCommand implements Callable<Integer> {
               paramLabel = "COLUMNFAMILY",
               description = "The column family name to filter for")
           final String columnFamilyName) {
-    System.out.print("ColumnFamily,Key,Value");
+    System.out.print("{\"data\":[");
     final var experimental = new Experimental(partitionPath);
+    final var counter = new AtomicInteger(0);
     experimental.visitDBWithJsonValues(
         ((cf, key, valueJson) -> {
           if (columnFamilyName == null
               || columnFamilyName.isEmpty()
               || cf.toString().equals(columnFamilyName)) {
-            System.out.printf("\n%s,%s,%s", cf, new String(key), valueJson);
+            if (counter.getAndIncrement() >= 1) {
+              System.out.printf(",");
+            }
+            System.out.printf(
+                "\n{\"cf\":\"%s\",\"key\":\"%s\",\"value\":%s}",
+                cf, HexFormat.ofDelimiter(" ").formatHex(key), valueJson);
           }
         }));
+    System.out.print("]}");
     return 0;
   }
 }

--- a/cli/src/main/java/io/zell/zdb/StateCommand.java
+++ b/cli/src/main/java/io/zell/zdb/StateCommand.java
@@ -49,6 +49,7 @@ public class StateCommand implements Callable<Integer> {
               paramLabel = "COLUMNFAMILY",
               description = "The column family name to filter for")
           final String columnFamilyName) {
+    // we print incrementally in order to avoid to build up big state in the application
     System.out.print("{\"data\":[");
     final var experimental = new Experimental(partitionPath);
     final var counter = new AtomicInteger(0);
@@ -58,7 +59,7 @@ public class StateCommand implements Callable<Integer> {
               || columnFamilyName.isEmpty()
               || cf.toString().equals(columnFamilyName)) {
             if (counter.getAndIncrement() >= 1) {
-              System.out.printf(",");
+              System.out.print(',');
             }
             System.out.printf(
                 "\n{\"cf\":\"%s\",\"key\":\"%s\",\"value\":%s}",

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Print the complete key-value pairs as valid json, together in a data object. The key will be printed in a hex format, in order to visualize the key correctly. Later we can add search for it.


Example
```
....
    {
      "cf": "INCIDENTS",
      "key": "00 00 00 00 00 00 00 22 00 08 00 00 00 00 87 c4",
      "value": {
        "incidentRecord": {
          "errorType": "EXTRACT_VALUE_ERROR",
          "errorMessage": "failed to evaluate expression 'read': no variable found for name 'read'",
          "bpmnProcessId": "Process_372fbfc7-9a4a-4f0b-aee5-bd96ed3e3e5d",
          "processDefinitionKey": 2251799813686656,
          "processInstanceKey": 2251799813686738,
          "elementId": "Gateway_0ad4338",
          "elementInstanceKey": 2251799813719626,
          "jobKey": -1,
          "variableScopeKey": 2251799813719626
        }
      }
    },
    {
      "cf": "INCIDENTS",
      "key": "00 00 00 00 00 00 00 22 00 08 00 00 00 00 87 c9",
      "value": {
        "incidentRecord": {
          "errorType": "EXTRACT_VALUE_ERROR",
          "errorMessage": "failed to evaluate expression 'read': no variable found for name 'read'",
          "bpmnProcessId": "Process_372fbfc7-9a4a-4f0b-aee5-bd96ed3e3e5d",
          "processDefinitionKey": 2251799813686656,
          "processInstanceKey": 2251799813686738,
          "elementId": "Gateway_0ad4338",
          "elementInstanceKey": 2251799813719632,
          "jobKey": -1,
          "variableScopeKey": 2251799813719632
        }
      }
    }
  ]
}
```