### PR TITLE
Upgrade Zeebe to 8.2.0

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -29,7 +29,6 @@
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <zeebe-test-container.version>3.5.2</zeebe-test-container.version>
-    <zeebe.version>8.1.8</zeebe.version>
     <version.slf4j>2.0.7</version.slf4j>
     <version.awaitility>4.2.0</version.awaitility>
     <jackson-databind.version>2.13.0</jackson-databind.version>

--- a/backend/src/main/kotlin/io/zell/zdb/db/readonly/transaction/ReadonlyTransactionDb.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/db/readonly/transaction/ReadonlyTransactionDb.kt
@@ -1,11 +1,9 @@
 package io.zell.zdb.db.readonly.transaction
 
-import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration
-import io.camunda.zeebe.engine.state.ZbColumnFamilies
+import io.camunda.zeebe.protocol.ZbColumnFamilies
 import org.rocksdb.ColumnFamilyHandle
 import org.rocksdb.OptimisticTransactionDB
 import org.rocksdb.RocksDB
-import java.io.File
 import java.nio.file.Path
 
 public class ReadonlyTransactionDb : ZeebeTransactionDb<ZbColumnFamilies> {

--- a/backend/src/main/kotlin/io/zell/zdb/log/ApplicationRecord.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/ApplicationRecord.kt
@@ -1,7 +1,6 @@
 package io.zell.zdb.log
 
-import io.camunda.zeebe.streamprocessor.TypedRecordImpl
-import kotlinx.serialization.json.Json
+import io.camunda.zeebe.stream.impl.records.TypedRecordImpl
 
 class ApplicationRecord(val index: Long, val term : Long) : PersistedRecord {
     val entries = mutableListOf<TypedRecordImpl>()

--- a/backend/src/main/kotlin/io/zell/zdb/log/LogContent.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogContent.kt
@@ -1,12 +1,13 @@
 package io.zell.zdb.log
 
 import io.atomix.raft.storage.log.IndexedRaftLogEntry
-import io.camunda.zeebe.engine.api.TypedRecord
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry
 import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord
 import io.camunda.zeebe.protocol.record.ValueType
-import io.camunda.zeebe.streamprocessor.TypedRecordImpl
+import io.camunda.zeebe.stream.api.records.TypedRecord
+import io.camunda.zeebe.stream.impl.records.TypedRecordImpl
 import org.agrona.concurrent.UnsafeBuffer
 
 class LogContent {
@@ -18,7 +19,7 @@ class LogContent {
         ) {
             if (entry.isApplicationEntry) {
                 val applicationRecord = ApplicationRecord(entry.index(), entry.term())
-                val applicationEntry = entry.applicationEntry
+                val applicationEntry = entry.applicationEntry as SerializedApplicationEntry
 
                 val readBuffer = UnsafeBuffer(applicationEntry.data());
 

--- a/backend/src/main/kotlin/io/zell/zdb/log/LogFactory.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogFactory.kt
@@ -20,7 +20,9 @@ class LogFactory {
             val raftLog = RaftLog.builder()
                 .withDirectory(logPath.toFile())
                 .withName(partitionName)
-                .withMaxSegmentSize(MAX_SEGMENT_SIZE).build()
+                .withMaxSegmentSize(MAX_SEGMENT_SIZE)
+                .withMetaStore(NoopMetaStore)
+                .build()
 
             return raftLog.openUncommittedReader()
         }

--- a/backend/src/main/kotlin/io/zell/zdb/log/LogHelper.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogHelper.kt
@@ -1,10 +1,10 @@
 package io.zell.zdb.log
 
-import io.camunda.zeebe.engine.processing.streamprocessor.TypedEventRegistry
 import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl
 import io.camunda.zeebe.protocol.Protocol
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata
-import io.camunda.zeebe.streamprocessor.TypedRecordImpl
+import io.camunda.zeebe.stream.impl.TypedEventRegistry
+import io.camunda.zeebe.stream.impl.records.TypedRecordImpl
 import io.camunda.zeebe.util.ReflectUtil
 
 

--- a/backend/src/main/kotlin/io/zell/zdb/log/LogSearch.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogSearch.kt
@@ -1,6 +1,7 @@
 package io.zell.zdb.log
 
 import io.atomix.raft.storage.log.RaftLogReader
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry
 import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata
 import io.camunda.zeebe.protocol.record.Record
@@ -23,7 +24,7 @@ class LogSearch (logPath: Path) {
             val entry = reader.next()
 
             if (entry.isApplicationEntry) {
-                val applicationEntry = entry.applicationEntry
+                val applicationEntry = entry.applicationEntry as SerializedApplicationEntry
 
                 val readBuffer = UnsafeBuffer(applicationEntry.data());
                 val loggedEvent = LoggedEventImpl();

--- a/backend/src/main/kotlin/io/zell/zdb/log/NoopMetaStore.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/NoopMetaStore.kt
@@ -1,0 +1,10 @@
+package io.zell.zdb.log
+
+import io.camunda.zeebe.journal.JournalMetaStore
+
+object NoopMetaStore : JournalMetaStore {
+    override fun storeLastFlushedIndex(index: Long) {}
+    override fun loadLastFlushedIndex(): Long {
+        return 0
+    }
+}

--- a/backend/src/main/kotlin/io/zell/zdb/state/Experimental.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/state/Experimental.kt
@@ -1,8 +1,7 @@
 package io.zell.zdb.state
 
 import io.camunda.zeebe.db.impl.ZeebeDbConstants
-import io.camunda.zeebe.engine.state.ZbColumnFamilies
-import io.camunda.zeebe.msgpack.spec.MsgPackHelper
+import io.camunda.zeebe.protocol.ZbColumnFamilies
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -10,10 +9,8 @@ import org.agrona.concurrent.UnsafeBuffer
 import org.rocksdb.OptimisticTransactionDB
 import org.rocksdb.ReadOptions
 import org.rocksdb.RocksDB
-import java.nio.ByteOrder
 import java.nio.file.Path
-import java.util.EnumMap
-import java.util.function.Function
+import java.util.*
 
 class Experimental(private var rocksDb: RocksDB) {
         constructor(statePath: Path) : this(OptimisticTransactionDB.openReadOnly(statePath.toString()))

--- a/backend/src/main/kotlin/io/zell/zdb/state/blacklist/BlacklistState.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/state/blacklist/BlacklistState.kt
@@ -2,8 +2,7 @@ package io.zell.zdb.state.blacklist
 
 import io.camunda.zeebe.db.impl.DbLong
 import io.camunda.zeebe.db.impl.DbNil
-import io.camunda.zeebe.engine.state.ZbColumnFamilies
-import io.camunda.zeebe.engine.state.ZeebeDbState
+import io.camunda.zeebe.protocol.ZbColumnFamilies
 import io.zell.zdb.db.readonly.transaction.ReadonlyTransactionDb
 import java.nio.file.Path
 
@@ -16,7 +15,8 @@ class BlacklistState(private var readonlyDb: ReadonlyTransactionDb) {
 
         val processInstanceKey = DbLong()
         val blackListColumnFamily =
-            readonlyDb.createColumnFamily(ZbColumnFamilies.BLACKLIST,
+            readonlyDb.createColumnFamily(
+                ZbColumnFamilies.BLACKLIST,
                 readonlyDb.createContext(),
                 processInstanceKey,
                 DbNil.INSTANCE)

--- a/backend/src/main/kotlin/io/zell/zdb/state/general/GeneralState.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/state/general/GeneralState.kt
@@ -4,11 +4,11 @@ import io.camunda.zeebe.db.impl.DbCompositeKey
 import io.camunda.zeebe.db.impl.DbLong
 import io.camunda.zeebe.db.impl.DbNil
 import io.camunda.zeebe.db.impl.DbString
-import io.camunda.zeebe.engine.state.ZbColumnFamilies
-import io.camunda.zeebe.engine.state.ZeebeDbState
+import io.camunda.zeebe.engine.state.ProcessingDbState
+import io.camunda.zeebe.engine.state.immutable.ProcessingState
 import io.camunda.zeebe.engine.state.variable.VariableInstance
-import io.camunda.zeebe.streamprocessor.state.DbLastProcessedPositionState
-import io.camunda.zeebe.streamprocessor.state.LastProcessedPositionState
+import io.camunda.zeebe.protocol.ZbColumnFamilies
+import io.camunda.zeebe.stream.impl.state.DbLastProcessedPositionState
 import io.zell.zdb.db.readonly.transaction.ReadonlyTransactionDb
 import io.zell.zdb.state.incident.IncidentState
 import io.zell.zdb.state.instance.InstanceState
@@ -16,12 +16,12 @@ import java.nio.file.Path
 
 class GeneralState(statePath: Path) {
 
-    private var zeebeDbState: ZeebeDbState
+    private var zeebeDbState: ProcessingState
     private var readonlyDb: ReadonlyTransactionDb
 
     init {
         readonlyDb = ReadonlyTransactionDb.openReadonlyDb(statePath)
-        zeebeDbState = ZeebeDbState(1, readonlyDb, readonlyDb.createContext(), { 1 })
+        zeebeDbState = ProcessingDbState(1, readonlyDb, readonlyDb.createContext(), { 1 })
     }
 
     fun generalDetails(): GeneralDetails {

--- a/backend/src/main/kotlin/io/zell/zdb/state/incident/IncidentState.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/state/incident/IncidentState.kt
@@ -1,20 +1,21 @@
 package io.zell.zdb.state.incident
 
 import io.camunda.zeebe.db.impl.DbLong
-import io.camunda.zeebe.engine.state.ZbColumnFamilies
-import io.camunda.zeebe.engine.state.ZeebeDbState
+import io.camunda.zeebe.engine.state.ProcessingDbState
+import io.camunda.zeebe.engine.state.immutable.ProcessingState
 import io.camunda.zeebe.engine.state.instance.Incident
+import io.camunda.zeebe.protocol.ZbColumnFamilies
 import io.zell.zdb.db.readonly.transaction.ReadonlyTransactionDb
 import java.nio.file.Path
 
 class IncidentState(readonlyDb: ReadonlyTransactionDb) {
 
-    private var zeebeDbState: ZeebeDbState
+    private var zeebeDbState: ProcessingState
     private var readonlyDb: ReadonlyTransactionDb
 
     init {
         this.readonlyDb = readonlyDb
-        zeebeDbState = ZeebeDbState(1, readonlyDb, readonlyDb.createContext(), { 1 })
+        zeebeDbState = ProcessingDbState(1, readonlyDb, readonlyDb.createContext(), { 1 })
     }
 
     constructor(statePath: Path) : this(ReadonlyTransactionDb.openReadonlyDb(statePath))

--- a/backend/src/main/kotlin/io/zell/zdb/state/instance/InstanceState.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/state/instance/InstanceState.kt
@@ -1,9 +1,10 @@
 package io.zell.zdb.state.instance
 
 import io.camunda.zeebe.db.impl.DbLong
-import io.camunda.zeebe.engine.state.ZbColumnFamilies
-import io.camunda.zeebe.engine.state.ZeebeDbState
+import io.camunda.zeebe.engine.state.ProcessingDbState
+import io.camunda.zeebe.engine.state.immutable.ProcessingState
 import io.camunda.zeebe.engine.state.instance.ElementInstance
+import io.camunda.zeebe.protocol.ZbColumnFamilies
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent
 import io.zell.zdb.db.readonly.transaction.ReadonlyTransactionDb
@@ -11,12 +12,12 @@ import java.nio.file.Path
 
 class InstanceState(readonlyTransactionDb: ReadonlyTransactionDb) {
 
-    private var zeebeDbState: ZeebeDbState
+    private var zeebeDbState: ProcessingState
     private var readonlyDb : ReadonlyTransactionDb
 
     init {
         readonlyDb = readonlyTransactionDb
-        zeebeDbState = ZeebeDbState(1, readonlyDb, readonlyDb.createContext(), { 1 })
+        zeebeDbState = ProcessingDbState(1, readonlyDb, readonlyDb.createContext(), { 1 })
     }
 
     constructor(statePath: Path) : this(ReadonlyTransactionDb.openReadonlyDb(statePath))

--- a/backend/src/main/kotlin/io/zell/zdb/state/process/ProcessState.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/state/process/ProcessState.kt
@@ -1,18 +1,18 @@
 package io.zell.zdb.state.process
 
-import io.camunda.zeebe.engine.state.KeyGenerator
-import io.camunda.zeebe.engine.state.ZeebeDbState
+import io.camunda.zeebe.engine.state.ProcessingDbState
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess
+import io.camunda.zeebe.engine.state.immutable.ProcessingState
 import io.zell.zdb.db.readonly.transaction.ReadonlyTransactionDb
 import java.nio.file.Path
 
 class ProcessState(statePath: Path) {
 
-    private var zeebeDbState: ZeebeDbState
+    private var zeebeDbState: ProcessingState
 
     init {
         val readonlyDb = ReadonlyTransactionDb.openReadonlyDb(statePath)
-        zeebeDbState = ZeebeDbState(1, readonlyDb, readonlyDb.createContext(), { 1 })
+        zeebeDbState = ProcessingDbState(1, readonlyDb, readonlyDb.createContext(), { 1 })
     }
 
     fun listProcesses(): List<ProcessMeta> {

--- a/backend/src/test/kotlin/LogHelperTest.java
+++ b/backend/src/test/kotlin/LogHelperTest.java
@@ -1,14 +1,14 @@
-import static org.assertj.core.api.Assertions.assertThat;
-
-import io.camunda.zeebe.dispatcher.impl.log.DataFrameDescriptor;
 import io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor;
 import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl;
+import io.camunda.zeebe.logstreams.impl.serializer.DataFrameDescriptor;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.zell.zdb.log.LogHelperKt;
 import org.agrona.ExpandableArrayBuffer;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LogHelperTest {
 

--- a/backend/src/test/kotlin/ZeebeBlacklistStateTest.java
+++ b/backend/src/test/kotlin/ZeebeBlacklistStateTest.java
@@ -1,31 +1,11 @@
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.FileUtil;
 import io.zeebe.containers.ZeebeContainer;
 import io.zell.zdb.ZeebePaths;
-import io.zell.zdb.log.LogContentReader;
 import io.zell.zdb.state.blacklist.BlacklistState;
-import io.zell.zdb.state.general.GeneralState;
-import io.zell.zdb.state.incident.IncidentState;
-import io.zell.zdb.state.instance.InstanceDetails;
-import io.zell.zdb.state.instance.InstanceState;
-import io.zell.zdb.state.process.ProcessState;
-import java.io.File;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -33,6 +13,14 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
 public class ZeebeBlacklistStateTest {
@@ -57,6 +45,7 @@ public class ZeebeBlacklistStateTest {
 
   @Container
   public static ZeebeContainer zeebeContainer = new ZeebeContainer()
+      .withEnv("ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL", "false")
       /* run the container with the current user, in order to access the data and delete it later */
       .withCreateContainerCmdModifier(cmd -> cmd.withUser(TestUtils.getRunAsUser()))
       .withFileSystemBind(tempDir.getPath(), CONTAINER_PATH, BindMode.READ_WRITE);

--- a/backend/src/test/kotlin/ZeebeLogTest.java
+++ b/backend/src/test/kotlin/ZeebeLogTest.java
@@ -130,8 +130,8 @@ public class ZeebeLogTest {
     final var status = logStatus.status();
 
     // then
-    assertThat(status.getHighestIndex()).isEqualTo(24);
-    assertThat(status.getScannedEntries()).isEqualTo(24);
+    assertThat(status.getHighestIndex()).isEqualTo(13);
+    assertThat(status.getScannedEntries()).isEqualTo(13);
     assertThat(status.getHighestTerm()).isEqualTo(1);
     assertThat(status.getHighestRecordPosition()).isEqualTo(60);
 
@@ -195,7 +195,7 @@ public class ZeebeLogTest {
     final var content = logContentReader.content();
 
     // then
-    assertThat(content.getRecords()).hasSize(24);
+    assertThat(content.getRecords()).hasSize(13);
 
     final var objectMapper = new ObjectMapper();
     final var jsonNode = objectMapper.readTree(content.toString());

--- a/backend/src/test/kotlin/ZeebeLogTest.java
+++ b/backend/src/test/kotlin/ZeebeLogTest.java
@@ -4,7 +4,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.streamprocessor.TypedRecordImpl;
+import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
 import io.camunda.zeebe.util.FileUtil;
 import io.zeebe.containers.ZeebeContainer;
 import io.zell.zdb.ZeebePaths;

--- a/backend/src/test/kotlin/ZeebeStateTest.java
+++ b/backend/src/test/kotlin/ZeebeStateTest.java
@@ -1,11 +1,9 @@
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
-import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
@@ -19,6 +17,13 @@ import io.zell.zdb.state.incident.IncidentState;
 import io.zell.zdb.state.instance.InstanceDetails;
 import io.zell.zdb.state.instance.InstanceState;
 import io.zell.zdb.state.process.ProcessState;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
 import java.io.File;
 import java.time.Duration;
 import java.util.HashMap;
@@ -27,12 +32,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.BindMode;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
 public class ZeebeStateTest {

--- a/backend/src/test/kotlin/ZeebeStateTest.java
+++ b/backend/src/test/kotlin/ZeebeStateTest.java
@@ -139,7 +139,7 @@ public class ZeebeStateTest {
     experimental.visitDBWithJsonValues(jsonVisitor);
 
     // then
-    assertThat(incidentMap).containsValue("{\"incidentRecord\":{\"errorType\":\"IO_MAPPING_ERROR\",\"errorMessage\":\"failed to evaluate expression '{bar:foo}': no variable found for name 'foo'\",\"bpmnProcessId\":\"process\",\"processDefinitionKey\":2251799813685249,\"processInstanceKey\":2251799813685251,\"elementId\":\"incidentTask\",\"elementInstanceKey\":2251799813685262,\"jobKey\":-1,\"variableScopeKey\":2251799813685262}}");
+    assertThat(incidentMap).containsValue("{\"incidentRecord\":{\"errorType\":\"IO_MAPPING_ERROR\",\"errorMessage\":\"failed to evaluate expression '{bar:foo}': no variable found for name 'foo'\",\"bpmnProcessId\":\"process\",\"processDefinitionKey\":2251799813685249,\"processInstanceKey\":2251799813685251,\"elementId\":\"incidentTask\",\"elementInstanceKey\":2251799813685260,\"jobKey\":-1,\"variableScopeKey\":2251799813685260}}");
   }
 
   @Test

--- a/backend/src/test/kotlin/ZeebeStateTest.java
+++ b/backend/src/test/kotlin/ZeebeStateTest.java
@@ -62,6 +62,8 @@ public class ZeebeStateTest {
 
   @Container
   public static ZeebeContainer zeebeContainer = new ZeebeContainer()
+      /* Enable WAL to ensure tests can read from open RocksDB */
+      .withEnv("ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL", "false")
       /* run the container with the current user, in order to access the data and delete it later */
       .withCreateContainerCmdModifier(cmd -> cmd.withUser(TestUtils.getRunAsUser()))
       .withFileSystemBind(tempDir.getPath(), CONTAINER_PATH, BindMode.READ_WRITE);

--- a/backend/src/test/kotlin/ZeebeTest.java
+++ b/backend/src/test/kotlin/ZeebeTest.java
@@ -26,7 +26,9 @@ public class ZeebeTest {
   public File tempDir = new File("/tmp/", "data-" + ThreadLocalRandom.current().nextLong());
 
   @Container
-  public ZeebeContainer zeebeContainer = new ZeebeContainer().withFileSystemBind(tempDir.getPath(), "/usr/local/zeebe/data/", BindMode.READ_WRITE);
+  public ZeebeContainer zeebeContainer = new ZeebeContainer()
+          .withEnv("ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL", "false")
+          .withFileSystemBind(tempDir.getPath(), "/usr/local/zeebe/data/", BindMode.READ_WRITE);
 
   /**
    * Just ot verify whether test container works with Zeebe Client.

--- a/backend/src/test/kotlin/ZeebeTest.java
+++ b/backend/src/test/kotlin/ZeebeTest.java
@@ -1,36 +1,24 @@
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
-import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransactionDb;
-import io.camunda.zeebe.engine.state.KeyGenerator;
-import io.camunda.zeebe.engine.state.ZbColumnFamilies;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
+import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
-import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
-import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.zeebe.containers.ZeebeContainer;
 import io.zell.zdb.ZeebePaths;
 import io.zell.zdb.db.readonly.transaction.ReadonlyTransactionDb;
-import java.io.File;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.concurrent.ThreadLocalRandom;
 import org.junit.jupiter.api.Test;
-import org.rocksdb.DBOptions;
-import org.rocksdb.OptimisticTransactionDB;
-import org.rocksdb.RocksDB;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
 public class ZeebeTest {
@@ -98,7 +86,7 @@ public class ZeebeTest {
     // when
     final var readonlyTransactionDb = ReadonlyTransactionDb.Companion
         .openReadonlyDb(ZeebePaths.Companion.getRuntimePath(tempDir, "1"));
-    var zeebeState = new ZeebeDbState(1, readonlyTransactionDb, readonlyTransactionDb.createContext(), () -> 1);
+    var zeebeState = new ProcessingDbState(1, readonlyTransactionDb, readonlyTransactionDb.createContext(), () -> 1);
 
     // then
     final var processState = zeebeState.getProcessState();

--- a/cli/src/main/java/io/zell/zdb/StateCommand.java
+++ b/cli/src/main/java/io/zell/zdb/StateCommand.java
@@ -7,14 +7,15 @@
  */
 package io.zell.zdb;
 
-import io.camunda.zeebe.engine.state.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.zell.zdb.state.Experimental;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
 import java.nio.file.Path;
 import java.util.HexFormat;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
 
 // THIS IS IN ALPHA STATE
 @Command(


### PR DESCRIPTION
This should make zdb compatible with  8.2.0:

1. Various moves and renames of Zeebe internal classes
2. Enabling of RocksDB WAL in various tests. Otherwise, the rocksdb instance opened in tests doesn't see all writes. This was new to me. Maybe this impacts not just tests since you can point zdb to a runtime dir where the same could happen?
3. Updates expected log indices. I didn't check in detail but probably changed because of batch processing?
4. Updates expected state keys. I think this changed because of the stream platform & engine split?
5. Provides a No-Op implementation of `MetaStore` which I think is not used by zdb. 