### PR TITLE
Support incremental read of log

### DIFF
--- a/backend/src/main/kotlin/io/zell/zdb/log/ApplicationRecord.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/ApplicationRecord.kt
@@ -17,7 +17,7 @@ package io.zell.zdb.log
 
 import io.camunda.zeebe.stream.impl.records.TypedRecordImpl
 
-class ApplicationRecord(val index: Long, val term : Long) : PersistedRecord {
+class ApplicationRecord(val index: Long, val term: Long, val highestPosition: Long, val lowestPosition: Long) : PersistedRecord {
     val entries = mutableListOf<TypedRecordImpl>()
 
     override fun index(): Long {
@@ -29,8 +29,7 @@ class ApplicationRecord(val index: Long, val term : Long) : PersistedRecord {
     }
 
     override fun toString(): String {
-
         val entriesJson = entries.map { it.toJson() }.joinToString()
-        return "{\"index\":$index, \"term\":$term, \"entries\":[${entriesJson}]}"
+        return """{"index":$index, "term":$term,"highestPosition":$highestPosition,"lowestPosition":$lowestPosition,"entries":[${entriesJson}]}"""
     }
 }

--- a/backend/src/main/kotlin/io/zell/zdb/log/LogContentReader.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogContentReader.kt
@@ -15,19 +15,70 @@
  */
 package io.zell.zdb.log
 
+import io.atomix.raft.storage.log.IndexedRaftLogEntry
 import io.atomix.raft.storage.log.RaftLogReader
-import io.zell.zdb.journal.JournalReader
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry
+import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata
+import org.agrona.concurrent.UnsafeBuffer
 import java.nio.file.Path
 
-class LogContentReader(logPath: Path) {
+class LogContentReader(logPath: Path) : Iterator<PersistedRecord> {
 
     private val reader: RaftLogReader = LogFactory.newReader(logPath)
 
-    fun content(): LogContent {
+    override fun hasNext(): Boolean {
+        return reader.hasNext();
+    }
+
+    override fun next(): PersistedRecord {
+        val next = reader.next()
+        return convertToPersistedRecord(next)
+    }
+
+    private fun convertToPersistedRecord(
+        entry: IndexedRaftLogEntry,
+    ) : PersistedRecord {
+        if (entry.isApplicationEntry) {
+            val applicationEntry = entry.applicationEntry as SerializedApplicationEntry
+            val applicationRecord = ApplicationRecord(entry.index(), entry.term(),
+                applicationEntry.highestPosition, applicationEntry.lowestPosition)
+
+            val readBuffer = UnsafeBuffer(applicationEntry.data());
+
+            var offset = 0;
+            do {
+                val loggedEvent = LoggedEventImpl();
+                val metadata = RecordMetadata();
+
+                loggedEvent.wrap(readBuffer, offset)
+                loggedEvent.readMetadata(metadata)
+
+                val typedEvent = convertToTypedEvent(loggedEvent, metadata)
+
+                applicationRecord.entries.add(typedEvent)
+
+                offset += loggedEvent.getLength();
+            } while (offset < readBuffer.capacity());
+            return applicationRecord
+        } else {
+            return RaftRecord(entry.index(), entry.term())
+        }
+    }
+
+    fun readAll(): LogContent {
         val logContent = LogContent()
-        reader.forEach {
-            LogContent.addEntryToContent(it, logContent)
+        this.forEach {
+            logContent.records.add(it)
         }
         return logContent
+    }
+
+    fun seekToPosition(position: Long) {
+        reader.seekToAsqn(position);
+    }
+
+    fun seekToIndex(index: Long) {
+        reader.seek(index)
     }
 }

--- a/backend/src/test/kotlin/ZeebeLogTest.java
+++ b/backend/src/test/kotlin/ZeebeLogTest.java
@@ -197,7 +197,7 @@ public class ZeebeLogTest {
     var logContentReader = new LogContentReader(logPath);
 
     // when
-    final var content = logContentReader.content();
+    final var content = logContentReader.readAll();
 
     // then
     assertThat(content.getRecords()).hasSize(13);
@@ -212,7 +212,7 @@ public class ZeebeLogTest {
     // given
     final var logPath = ZeebePaths.Companion.getLogPath(tempDir, "1");
     var logContentReader = new LogContentReader(logPath);
-    final var content = logContentReader.content();
+    final var content = logContentReader.readAll();
 
     // when
     final var dotFileContent = content.asDotFile();
@@ -228,7 +228,7 @@ public class ZeebeLogTest {
     var logContentReader = new LogContentReader(logPath);
 
     // when
-    final var content = logContentReader.content();
+    final var content = logContentReader.readAll();
 
     // then
     // validate that records are not duplicated in LogContent
@@ -289,11 +289,10 @@ public class ZeebeLogTest {
     final var index = 7;
 
     // when
-    final var logContent = logSearch.searchIndex(index);
+    final var record = logSearch.searchIndex(index);
 
     // then
-    assertThat(logContent).isNotNull();
-    assertThat(logContent.getRecords()).hasSize(1);
+    assertThat(record).isNotNull();
   }
 
   @Test
@@ -304,15 +303,15 @@ public class ZeebeLogTest {
     final var index = 7;
 
     // when
-    final var logContent = logSearch.searchIndex(index);
+    final var record = logSearch.searchIndex(index);
 
     // then
     // validate that records are not duplicated in LogContent
-    assertThat(logContent.getRecords())
-        .filteredOn(ApplicationRecord.class::isInstance)
-        .asInstanceOf(InstanceOfAssertFactories.list(ApplicationRecord.class))
-        .flatExtracting(ApplicationRecord::getEntries)
-        .extracting(TypedRecordImpl::getPosition)
+    assertThat(record)
+        .asInstanceOf(InstanceOfAssertFactories.type(ApplicationRecord.class))
+        .extracting(ApplicationRecord::getEntries)
+        .asInstanceOf(InstanceOfAssertFactories.list(Record.class))
+        .extracting(Record::getPosition)
         .doesNotHaveDuplicates();
   }
 

--- a/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
+++ b/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
@@ -49,7 +49,7 @@ public class LogPrintCommand implements Callable<Integer> {
       final var logContent = logContentReader.readAll();
       System.out.println(logContent.asDotFile());
     } else {
-      System.out.println("{");
+      System.out.println("[");
       for (LogContentReader it = logContentReader; it.hasNext(); ) {
         var record = it.next();
         System.out.println(record);
@@ -57,7 +57,7 @@ public class LogPrintCommand implements Callable<Integer> {
           System.out.print(",");
         }
       }
-      System.out.println("}");
+      System.out.println("]");
     }
 
     return 0;

--- a/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
+++ b/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
@@ -44,11 +44,20 @@ public class LogPrintCommand implements Callable<Integer> {
   public Integer call() {
     final Path partitionPath = spec.findOption("-p").getValue();
     final var logContentReader = new LogContentReader(partitionPath);
-    final var logContent = logContentReader.content();
     if (format == Format.DOT) {
+      // for backwards compatibility
+      final var logContent = logContentReader.readAll();
       System.out.println(logContent.asDotFile());
     } else {
-      System.out.println(logContent);
+      System.out.println("{");
+      for (LogContentReader it = logContentReader; it.hasNext(); ) {
+        var record = it.next();
+        System.out.println(record);
+        if (logContentReader.hasNext()) {
+          System.out.print(",");
+        }
+      }
+      System.out.println("}");
     }
 
     return 0;

--- a/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
+++ b/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
@@ -51,7 +51,7 @@ public class LogPrintCommand implements Callable<Integer> {
     } else {
       System.out.println("[");
       for (LogContentReader it = logContentReader; it.hasNext(); ) {
-        var record = it.next();
+        final var record = it.next();
         System.out.println(record);
         if (logContentReader.hasNext()) {
           System.out.print(",");


### PR DESCRIPTION
Reads and prints the Zeebe log incremental, instead of accumulating the whole log in the CLI state. This avoids OOM on huge logs.

closes https://github.com/Zelldon/zdb/issues/120