### PR TITLE
Filter log for process instance

### DIFF
--- a/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
+++ b/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
@@ -15,8 +15,10 @@
  */
 package io.zell.zdb;
 
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.zell.zdb.log.ApplicationRecord;
 import io.zell.zdb.log.LogContentReader;
+import io.zell.zdb.log.PersistedRecord;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
@@ -53,6 +55,12 @@ public class LogPrintCommand implements Callable<Integer> {
       defaultValue = Long.MAX_VALUE + "")
   private long toPosition;
 
+  @Option(
+      names = {"--instanceKey"},
+      description = "Print's the log only containing records with the given process instance key.",
+      defaultValue = "0")
+  private long instanceKey;
+
   @Override
   public Integer call() {
     final Path partitionPath = spec.findOption("-p").getValue();
@@ -62,23 +70,51 @@ public class LogPrintCommand implements Callable<Integer> {
       final var logContent = logContentReader.readAll();
       System.out.println(logContent.asDotFile());
     } else {
-      System.out.println("[");
-      logContentReader.seekToPosition(fromPosition);
-      while (logContentReader.hasNext()) {
-        final var record = logContentReader.next();
-        if (record instanceof ApplicationRecord engineRecord) {
-          if (engineRecord.getLowestPosition() > toPosition) {
-            break;
-          }
-        }
-        System.out.println(record);
-        if (logContentReader.hasNext()) {
-          System.out.print(",");
-        }
-      }
-      System.out.println("]");
+      printJson(logContentReader);
     }
 
     return 0;
+  }
+
+  private void printJson(LogContentReader logContentReader) {
+    System.out.println("[");
+    logContentReader.seekToPosition(fromPosition);
+    var separator = "";
+    while (logContentReader.hasNext()) {
+      final var record = logContentReader.next();
+      if (record instanceof ApplicationRecord engineRecord) {
+        if (engineRecord.getLowestPosition() > toPosition) {
+          break;
+        }
+      }
+
+      if (shouldPrintRecord(record)) {
+        System.out.print(separator + record);
+        separator = ",";
+      }
+    }
+    System.out.println("]");
+  }
+
+  private boolean shouldPrintRecord(PersistedRecord record) {
+    if (instanceKey == 0) {
+      return true;
+    } else {
+      if (record instanceof ApplicationRecord engineRecord) {
+        final var entries = engineRecord.getEntries();
+        boolean printRecord = false;
+        for (var entry : entries) {
+          if (entry.getValue() instanceof ProcessInstanceRelated instanceRelated) {
+            if (instanceRelated.getProcessInstanceKey() == instanceKey) {
+              printRecord = true;
+              break;
+            }
+          }
+        }
+        return printRecord;
+      } else {
+        return false;
+      }
+    }
   }
 }


### PR DESCRIPTION
Filters the log for a certain process instance, means it only prints records with the given process instance key.

The process instance key can be specified by `--instanceKey`