### PR TITLE
Fix path position in state list subcommand

### DIFF
--- a/cli/src/main/java/io/zell/zdb/StateCommand.java
+++ b/cli/src/main/java/io/zell/zdb/StateCommand.java
@@ -21,6 +21,8 @@ import java.nio.file.Path;
 import java.util.HexFormat;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -35,6 +37,7 @@ public class StateCommand implements Callable<Integer> {
       names = {"-p", "--path"},
       paramLabel = "PARTITION_PATH",
       description = "The path to the partition data (either runtime or snapshot in partition dir)",
+      scope = CommandLine.ScopeType.INHERIT,
       required = true)
   private Path partitionPath;
 

--- a/cli/src/main/java/io/zell/zdb/StateCommand.java
+++ b/cli/src/main/java/io/zell/zdb/StateCommand.java
@@ -17,14 +17,14 @@ package io.zell.zdb;
 
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.zell.zdb.state.Experimental;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
 import java.nio.file.Path;
 import java.util.HexFormat;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import picocli.CommandLine;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
 
 // THIS IS IN ALPHA STATE
 @Command(


### PR DESCRIPTION
The path option was not inherited which means it was not usable on the list subcommand.

closes https://github.com/Zelldon/zdb/issues/251