### PR TITLE
Move new log print logic to backend

### DIFF
--- a/backend/src/main/kotlin/io/zell/zdb/log/LogContentReader.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogContentReader.kt
@@ -20,23 +20,60 @@ import io.atomix.raft.storage.log.RaftLogReader
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry
 import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated
 import org.agrona.concurrent.UnsafeBuffer
 import java.nio.file.Path
+import kotlin.streams.asStream
 
 class LogContentReader(logPath: Path) : Iterator<PersistedRecord> {
 
     private val reader: RaftLogReader = LogFactory.newReader(logPath)
     private var isInLimit: (PersistedRecord) -> Boolean = { true }
+    private var applicationRecordFilter: ((ApplicationRecord) -> Boolean)? = null
     private lateinit var next: PersistedRecord
 
     override fun hasNext(): Boolean {
         val hasNext = reader.hasNext()
 
-        if (hasNext) {
-            next = convertToPersistedRecord(reader.next())
-            return isInLimit(next)
+        if (!hasNext) {
+            return false
         }
-        return false
+
+        next = convertToPersistedRecord(reader.next())
+        if (!isInLimit(next)) {
+            return false
+        }
+
+        if (applicationRecordFilter == null) {
+            return true
+        }
+
+        return applyFiltering()
+    }
+
+    private fun applyFiltering(): Boolean {
+        // when application record filter is given, we don't want to see RaftLogRecords
+        // they are filtered out implicitly here as well
+        val filterMatches = next is ApplicationRecord && applicationRecordFilter!!(next as ApplicationRecord)
+
+        if (filterMatches) {
+            return true
+        }
+
+        // we want to skip this record, since it doesn't apply to our filter
+        // we need to find the next matching record
+        var foundNext = false
+        while (!foundNext && reader.hasNext()) {
+            next = convertToPersistedRecord(reader.next())
+            if (!isInLimit(next)) {
+                break
+            }
+
+            if (next is ApplicationRecord) {
+                foundNext = applicationRecordFilter!!(next as ApplicationRecord)
+            }
+        }
+        return foundNext;
     }
 
     override fun next(): PersistedRecord {
@@ -92,6 +129,18 @@ class LogContentReader(logPath: Path) : Iterator<PersistedRecord> {
     fun limitToPosition(toPosition: Long) {
         isInLimit = { record: PersistedRecord ->
             record is RaftRecord || (record is ApplicationRecord && record.lowestPosition < toPosition)
+        }
+    }
+
+    fun filterForProcessInstance(instanceKey : Long) {
+        applicationRecordFilter = {
+            record : ApplicationRecord ->
+                record.entries.asSequence()
+                    .map { it.value }
+                    .filterIsInstance<ProcessInstanceRelated>()
+                    .asStream()
+                    .map { it.processInstanceKey }
+                    .anyMatch(instanceKey::equals)
         }
     }
 }

--- a/backend/src/test/kotlin/ZeebeLogTest.java
+++ b/backend/src/test/kotlin/ZeebeLogTest.java
@@ -23,10 +23,7 @@ import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
 import io.camunda.zeebe.util.FileUtil;
 import io.zeebe.containers.ZeebeContainer;
 import io.zell.zdb.ZeebePaths;
-import io.zell.zdb.log.ApplicationRecord;
-import io.zell.zdb.log.LogContentReader;
-import io.zell.zdb.log.LogSearch;
-import io.zell.zdb.log.LogStatus;
+import io.zell.zdb.log.*;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -37,7 +34,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
+import java.sql.Array;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
@@ -200,11 +200,269 @@ public class ZeebeLogTest {
     final var content = logContentReader.readAll();
 
     // then
-    assertThat(content.getRecords()).hasSize(13);
+    verifyCompleteLog(content.getRecords());
 
     final var objectMapper = new ObjectMapper();
     final var jsonNode = objectMapper.readTree(content.toString());
     assertThat(jsonNode).isNotNull(); // is valid json
+  }
+
+  @Test
+  public void shouldReadLogContentWithIterator() {
+    // given
+    final var logPath = ZeebePaths.Companion.getLogPath(tempDir, "1");
+    var logContentReader = new LogContentReader(logPath);
+    final var records = new ArrayList<PersistedRecord>();
+
+    // when
+    logContentReader.forEachRemaining(records::add);
+
+    // then
+    verifyCompleteLog(records);
+  }
+
+  @Test
+  public void shouldSkipFirstPartOfLog() {
+    // given
+    final var logPath = ZeebePaths.Companion.getLogPath(tempDir, "1");
+    var logContentReader = new LogContentReader(logPath);
+    final var records = new ArrayList<PersistedRecord>();
+    logContentReader.seekToPosition(10);
+
+    // when
+    logContentReader.forEachRemaining(records::add);
+
+    // then
+    assertThat(records).hasSize(9);
+    // we skip the first raft record
+    assertThat(records.stream().filter(RaftRecord.class::isInstance).count()).isEqualTo(0);
+    assertThat(records.stream().filter(ApplicationRecord.class::isInstance).count()).isEqualTo(9);
+
+    final var maxIndex = records.stream().map(PersistedRecord::index).max(Long::compareTo).get();
+    assertThat(maxIndex).isEqualTo(13);
+    final var minIndex = records.stream().map(PersistedRecord::index).min(Long::compareTo).get();
+    assertThat(minIndex).isEqualTo(5);
+
+    final var maxPosition = records.stream()
+            .filter(ApplicationRecord.class::isInstance)
+            .map(ApplicationRecord.class::cast)
+            .map(ApplicationRecord::getHighestPosition)
+            .max(Long::compareTo)
+            .orElseThrow();
+    assertThat(maxPosition).isEqualTo(60);
+    final var minPosition = records.stream()
+            .filter(ApplicationRecord.class::isInstance)
+            .map(ApplicationRecord.class::cast)
+            .map(ApplicationRecord::getLowestPosition)
+            .min(Long::compareTo)
+            .orElseThrow();
+    assertThat(minPosition).isEqualTo(7);
+  }
+
+  @Test
+  public void shouldNotSkipIfNegativeSeek() {
+    // given
+    final var logPath = ZeebePaths.Companion.getLogPath(tempDir, "1");
+    var logContentReader = new LogContentReader(logPath);
+    final var records = new ArrayList<PersistedRecord>();
+    logContentReader.seekToPosition(-1);
+
+    // when
+    logContentReader.forEachRemaining(records::add);
+
+    // then
+    verifyCompleteLog(records);
+  }
+
+  @Test
+  public void shouldNotSkipIfZeroSeek() {
+    // given
+    final var logPath = ZeebePaths.Companion.getLogPath(tempDir, "1");
+    var logContentReader = new LogContentReader(logPath);
+    final var records = new ArrayList<PersistedRecord>();
+    logContentReader.seekToPosition(0);
+
+    // when
+    logContentReader.forEachRemaining(records::add);
+
+    // then
+    verifyCompleteLog(records);
+  }
+
+  @Test
+  public void shouldSeekToEndOfLogIfNoExistingSeek() {
+    // given
+    final var logPath = ZeebePaths.Companion.getLogPath(tempDir, "1");
+    var logContentReader = new LogContentReader(logPath);
+    final var records = new ArrayList<PersistedRecord>();
+    logContentReader.seekToPosition(Long.MAX_VALUE);
+
+    // when
+    logContentReader.forEachRemaining(records::add);
+
+    // then
+    assertThat(records).hasSize(1);
+    assertThat(records.stream().filter(RaftRecord.class::isInstance).count()).isEqualTo(0);
+    assertThat(records.stream().filter(ApplicationRecord.class::isInstance).count()).isEqualTo(1);
+
+    final var maxIndex = records.stream().map(PersistedRecord::index).max(Long::compareTo).get();
+    assertThat(maxIndex).isEqualTo(13);
+    final var minIndex = records.stream().map(PersistedRecord::index).min(Long::compareTo).get();
+    assertThat(minIndex).isEqualTo(13);
+
+    final var maxPosition = records.stream()
+            .filter(ApplicationRecord.class::isInstance)
+            .map(ApplicationRecord.class::cast)
+            .map(ApplicationRecord::getHighestPosition)
+            .max(Long::compareTo)
+            .orElseThrow();
+    assertThat(maxPosition).isEqualTo(60);
+    final var minPosition = records.stream()
+            .filter(ApplicationRecord.class::isInstance)
+            .map(ApplicationRecord.class::cast)
+            .map(ApplicationRecord::getLowestPosition)
+            .min(Long::compareTo)
+            .orElseThrow();
+    assertThat(minPosition).isEqualTo(60);
+  }
+
+  @Test
+  public void shouldLimitLogToPosition() {
+    // given
+    final var logPath = ZeebePaths.Companion.getLogPath(tempDir, "1");
+    var logContentReader = new LogContentReader(logPath);
+    final var records = new ArrayList<PersistedRecord>();
+    logContentReader.limitToPosition(30);
+
+    // when
+    logContentReader.forEachRemaining(records::add);
+
+    // then
+    assertThat(records).hasSize(5);
+    assertThat(records.stream().filter(RaftRecord.class::isInstance).count()).isEqualTo(1);
+    assertThat(records.stream().filter(ApplicationRecord.class::isInstance).count()).isEqualTo(4);
+
+    final var maxIndex = records.stream().map(PersistedRecord::index).max(Long::compareTo).get();
+    assertThat(maxIndex).isEqualTo(5);
+    final var minIndex = records.stream().map(PersistedRecord::index).min(Long::compareTo).get();
+    assertThat(minIndex).isEqualTo(1);
+
+    final var maxPosition = records.stream()
+            .filter(ApplicationRecord.class::isInstance)
+            .map(ApplicationRecord.class::cast)
+            .map(ApplicationRecord::getHighestPosition)
+            .max(Long::compareTo)
+            .orElseThrow();
+    assertThat(maxPosition).isEqualTo(34);
+    final var minPosition = records.stream()
+            .filter(ApplicationRecord.class::isInstance)
+            .map(ApplicationRecord.class::cast)
+            .map(ApplicationRecord::getLowestPosition)
+            .min(Long::compareTo)
+            .orElseThrow();
+    assertThat(minPosition).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldSeekAndLimitLogWithPosition() {
+    // given
+    final var logPath = ZeebePaths.Companion.getLogPath(tempDir, "1");
+    var logContentReader = new LogContentReader(logPath);
+    final var records = new ArrayList<PersistedRecord>();
+    logContentReader.seekToPosition(5);
+    logContentReader.limitToPosition(30);
+
+    // when
+    logContentReader.forEachRemaining(records::add);
+
+    // then
+    assertThat(records).hasSize(3);
+    assertThat(records.stream().filter(RaftRecord.class::isInstance).count()).isEqualTo(0);
+    assertThat(records.stream().filter(ApplicationRecord.class::isInstance).count()).isEqualTo(3);
+
+    final var maxIndex = records.stream().map(PersistedRecord::index).max(Long::compareTo).get();
+    assertThat(maxIndex).isEqualTo(5);
+    final var minIndex = records.stream().map(PersistedRecord::index).min(Long::compareTo).get();
+    assertThat(minIndex).isEqualTo(3);
+
+    final var maxPosition = records.stream()
+            .filter(ApplicationRecord.class::isInstance)
+            .map(ApplicationRecord.class::cast)
+            .map(ApplicationRecord::getHighestPosition)
+            .max(Long::compareTo)
+            .orElseThrow();
+    assertThat(maxPosition).isEqualTo(34);
+    final var minPosition = records.stream()
+            .filter(ApplicationRecord.class::isInstance)
+            .map(ApplicationRecord.class::cast)
+            .map(ApplicationRecord::getLowestPosition)
+            .min(Long::compareTo)
+            .orElseThrow();
+    assertThat(minPosition).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldFilterWithProcessInstanceKey() {
+    // given
+    final var logPath = ZeebePaths.Companion.getLogPath(tempDir, "1");
+    var logContentReader = new LogContentReader(logPath);
+    final var records = new ArrayList<PersistedRecord>();
+    logContentReader.seekToPosition(5);
+    logContentReader.limitToPosition(30);
+
+    // when
+    logContentReader.forEachRemaining(records::add);
+
+    // then
+    assertThat(records).hasSize(3);
+    assertThat(records.stream().filter(RaftRecord.class::isInstance).count()).isEqualTo(0);
+    assertThat(records.stream().filter(ApplicationRecord.class::isInstance).count()).isEqualTo(3);
+
+    final var maxIndex = records.stream().map(PersistedRecord::index).max(Long::compareTo).get();
+    assertThat(maxIndex).isEqualTo(5);
+    final var minIndex = records.stream().map(PersistedRecord::index).min(Long::compareTo).get();
+    assertThat(minIndex).isEqualTo(3);
+
+    final var maxPosition = records.stream()
+            .filter(ApplicationRecord.class::isInstance)
+            .map(ApplicationRecord.class::cast)
+            .map(ApplicationRecord::getHighestPosition)
+            .max(Long::compareTo)
+            .orElseThrow();
+    assertThat(maxPosition).isEqualTo(34);
+    final var minPosition = records.stream()
+            .filter(ApplicationRecord.class::isInstance)
+            .map(ApplicationRecord.class::cast)
+            .map(ApplicationRecord::getLowestPosition)
+            .min(Long::compareTo)
+            .orElseThrow();
+    assertThat(minPosition).isEqualTo(2);
+  }
+
+  private static void verifyCompleteLog(List<PersistedRecord> records) {
+    assertThat(records).hasSize(13);
+    assertThat(records.stream().filter(RaftRecord.class::isInstance).count()).isEqualTo(1);
+    assertThat(records.stream().filter(ApplicationRecord.class::isInstance).count()).isEqualTo(12);
+
+    final var maxIndex = records.stream().map(PersistedRecord::index).max(Long::compareTo).get();
+    assertThat(maxIndex).isEqualTo(13);
+    final var minIndex = records.stream().map(PersistedRecord::index).min(Long::compareTo).get();
+    assertThat(minIndex).isEqualTo(1);
+
+    final var maxPosition = records.stream()
+            .filter(ApplicationRecord.class::isInstance)
+            .map(ApplicationRecord.class::cast)
+            .map(ApplicationRecord::getHighestPosition)
+            .max(Long::compareTo)
+            .orElseThrow();
+    assertThat(maxPosition).isEqualTo(60);
+    final var minPosition = records.stream()
+            .filter(ApplicationRecord.class::isInstance)
+            .map(ApplicationRecord.class::cast)
+            .map(ApplicationRecord::getLowestPosition)
+            .min(Long::compareTo)
+            .orElseThrow();
+    assertThat(minPosition).isEqualTo(1);
   }
 
   @Test

--- a/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
+++ b/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
@@ -42,19 +42,27 @@ public class LogPrintCommand implements Callable<Integer> {
 
   @Option(
       names = {"--from", "--fromPosition"},
-      description = "Print's the complete log from the given position.",
+      description = "Option to skip the begin of log and only print from the given position." +
+          " Note this is on best effort basis, since engine records are written in batches." +
+          " There might be some more records printed before the given position (part of the written batch).",
       defaultValue = "0")
   private long fromPosition;
 
   @Option(
       names = {"--to", "--toPosition"},
-      description = "Print's the complete log to the given position.",
+      description = "Option to set a limit to print the log only to the given position." +
+              " Note this is on best effort basis, since engine records are written in batches." +
+              " There might be some more records printed after the given position (part of the written batch).",
       defaultValue = Long.MAX_VALUE + "")
   private long toPosition;
 
   @Option(
       names = {"--instanceKey"},
-      description = "Print's the log only containing records with the given process instance key.",
+      description = "Filter to print only records which are part the specified process instance." +
+          " Note this is on best effort basis, since engine records are written in batches." +
+          " There might be some records printed which do not have an process instance key assigned." +
+          " RaftRecords are completely skipped, if this filter is applied."
+          ,
       defaultValue = "0")
   private long instanceKey;
 

--- a/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
+++ b/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
@@ -79,15 +79,11 @@ public class LogPrintCommand implements Callable<Integer> {
   private void printJson(LogContentReader logContentReader) {
     System.out.println("[");
     logContentReader.seekToPosition(fromPosition);
+    logContentReader.limitToPosition(toPosition);
     var separator = "";
     while (logContentReader.hasNext()) {
       final var record = logContentReader.next();
-      if (record instanceof ApplicationRecord engineRecord) {
-        if (engineRecord.getLowestPosition() > toPosition) {
-          break;
-        }
-      }
-
+     
       if (shouldPrintRecord(record)) {
         System.out.print(separator + record);
         separator = ",";

--- a/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
+++ b/cli/src/main/java/io/zell/zdb/LogPrintCommand.java
@@ -15,10 +15,7 @@
  */
 package io.zell.zdb;
 
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
-import io.zell.zdb.log.ApplicationRecord;
 import io.zell.zdb.log.LogContentReader;
-import io.zell.zdb.log.PersistedRecord;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
@@ -80,37 +77,17 @@ public class LogPrintCommand implements Callable<Integer> {
     System.out.println("[");
     logContentReader.seekToPosition(fromPosition);
     logContentReader.limitToPosition(toPosition);
+    if (instanceKey > 0) {
+      logContentReader.filterForProcessInstance(instanceKey);
+    }
+
     var separator = "";
     while (logContentReader.hasNext()) {
       final var record = logContentReader.next();
-     
-      if (shouldPrintRecord(record)) {
-        System.out.print(separator + record);
-        separator = ",";
-      }
+
+      System.out.print(separator + record);
+      separator = ",";
     }
     System.out.println("]");
-  }
-
-  private boolean shouldPrintRecord(PersistedRecord record) {
-    if (instanceKey == 0) {
-      return true;
-    } else {
-      if (record instanceof ApplicationRecord engineRecord) {
-        final var entries = engineRecord.getEntries();
-        boolean printRecord = false;
-        for (var entry : entries) {
-          if (entry.getValue() instanceof ProcessInstanceRelated instanceRelated) {
-            if (instanceRelated.getProcessInstanceKey() == instanceKey) {
-              printRecord = true;
-              break;
-            }
-          }
-        }
-        return printRecord;
-      } else {
-        return false;
-      }
-    }
   }
 }


### PR DESCRIPTION
Moves filtering and the from and to specifications to the backend such that we can better write test for that logic, and the CLI code becomes more simplified.

Furthermore, improved the command options descriptions in the cli.