### PR TITLE
Ignore empty async created segments

### DIFF
--- a/backend/src/main/kotlin/io/zell/zdb/journal/file/EmptySegmentException.java
+++ b/backend/src/main/kotlin/io/zell/zdb/journal/file/EmptySegmentException.java
@@ -1,0 +1,8 @@
+package io.zell.zdb.journal.file;
+
+/**
+ * Exception to mark that an empty segment was detected.
+ */
+public class EmptySegmentException extends RuntimeException {
+
+}

--- a/backend/src/main/kotlin/io/zell/zdb/journal/file/SegmentsManager.java
+++ b/backend/src/main/kotlin/io/zell/zdb/journal/file/SegmentsManager.java
@@ -143,6 +143,10 @@ final class SegmentsManager implements AutoCloseable {
         previousSegment = segment;
       } catch (final CorruptedJournalException e) {
         throw e;
+      } catch (EmptySegmentException ese) {
+        // here we know the segment was empty, likely to an incomplete write or async preparation
+        // we skip the segment
+         LOG.trace("Expected to read segment {}, but failed (potential due to corruption or incompleteness) will skip segment.", file.getName(), ese);
       }
     }
 

--- a/backend/src/test/kotlin/io/zell/zdb/v82/Version82Test.java
+++ b/backend/src/test/kotlin/io/zell/zdb/v82/Version82Test.java
@@ -42,7 +42,6 @@ import io.zell.zdb.state.ZeebeDbReader;
 import io.zell.zdb.state.incident.IncidentState;
 import io.zell.zdb.state.instance.InstanceState;
 import io.zell.zdb.state.process.ProcessState;
-import io.zell.zdb.v81.Version81Test;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
@@ -65,13 +64,13 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Testcontainers
 public class Version82Test {
+    private static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("camunda/zeebe:8.2.16");
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final BpmnModelInstance PROCESS =
             Bpmn.createExecutableProcess("process")
@@ -86,6 +85,62 @@ public class Version82Test {
                     .zeebeJobType("type")
                     .endEvent()
                     .done();
+    @Nested
+    public class LargeLogTest {
+        // earlier ZDB versions failed on large logs, because of segments were async created and incomplete
+        private static final Logger LOGGER =
+                LoggerFactory.getLogger(LargeLogTest.class);
+        private static final File TEMP_DIR = TestUtils.newTmpFolder(LargeLogTest.class);
+        private static final ZeebeContentCreator zeebeContentCreator = new ZeebeContentCreator(PROCESS);
+        @Container
+        public static ZeebeContainer zeebeContainer = new ZeebeContainer(DOCKER_IMAGE)
+                /* run the container with the current user, in order to access the data and delete it later */
+                .withCreateContainerCmdModifier(cmd -> cmd.withUser(TestUtils.getRunAsUser()))
+                // with 8.2 we disabled WAL per default
+                // we have to enabled it inorder to access the data from RocksDB
+                .withEnv("ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL", "false")
+                .withLogConsumer(new Slf4jLogConsumer(LOGGER))
+                .withFileSystemBind(TEMP_DIR.getPath(), TestUtils.CONTAINER_PATH, BindMode.READ_WRITE);
+
+        static {
+            TEMP_DIR.mkdirs();
+        }
+
+        @BeforeAll
+        public static void setup() {
+            zeebeContentCreator
+                    .createLargeContent(zeebeContainer.getExternalGatewayAddress());
+        }
+
+        @AfterAll
+        public static void cleanup() throws Exception {
+            FileUtil.deleteFolderIfExists(TEMP_DIR.toPath());
+        }
+
+        @Test
+        public void shouldReadStatusFromLog() {
+            // given
+            final var logPath = ZeebePaths.Companion.getLogPath(TEMP_DIR, "1");
+            var logStatus = new LogStatus(logPath);
+
+            // when
+            final var status = logStatus.status();
+
+            // then
+            assertThat(status.getHighestIndex()).isEqualTo(211);
+            assertThat(status.getHighestTerm()).isEqualTo(1);
+            assertThat(status.getHighestRecordPosition()).isEqualTo(258);
+            assertThat(status.getLowestIndex()).isEqualTo(1);
+            assertThat(status.getLowestRecordPosition()).isEqualTo(1);
+
+            assertThat(status.toString())
+                    .contains("lowestRecordPosition")
+                    .contains("highestRecordPosition")
+                    .contains("highestTerm")
+                    .contains("highestIndex")
+                    .contains("lowestIndex");
+        }
+    }
 
     @Nested
     public class ZeebeLogTest {
@@ -95,7 +150,7 @@ public class Version82Test {
         private static final File TEMP_DIR = TestUtils.newTmpFolder(ZeebeLogTest.class);
         private static final ZeebeContentCreator zeebeContentCreator = new ZeebeContentCreator(PROCESS);
         @Container
-        public static ZeebeContainer zeebeContainer = new ZeebeContainer(DockerImageName.parse("camunda/zeebe:8.2.16"))
+        public static ZeebeContainer zeebeContainer = new ZeebeContainer(DOCKER_IMAGE)
                 /* run the container with the current user, in order to access the data and delete it later */
                 .withCreateContainerCmdModifier(cmd -> cmd.withUser(TestUtils.getRunAsUser()))
                 // with 8.2 we disabled WAL per default
@@ -713,7 +768,7 @@ public class Version82Test {
         private static final File TEMP_DIR = TestUtils.newTmpFolder(ZeebeStateTest.class);
         private static final ZeebeContentCreator zeebeContentCreator = new ZeebeContentCreator(PROCESS);
         @Container
-        public static ZeebeContainer zeebeContainer = new ZeebeContainer(DockerImageName.parse("camunda/zeebe:8.2.16"))
+        public static ZeebeContainer zeebeContainer = new ZeebeContainer(DOCKER_IMAGE)
                 /* run the container with the current user, in order to access the data and delete it later */
                 .withCreateContainerCmdModifier(cmd -> cmd.withUser(TestUtils.getRunAsUser()))
                 // with 8.2 we disabled WAL per default

--- a/backend/src/test/kotlin/io/zell/zdb/v83/Version83Test.java
+++ b/backend/src/test/kotlin/io/zell/zdb/v83/Version83Test.java
@@ -42,7 +42,7 @@ import io.zell.zdb.state.ZeebeDbReader;
 import io.zell.zdb.state.incident.IncidentState;
 import io.zell.zdb.state.instance.InstanceState;
 import io.zell.zdb.state.process.ProcessState;
-import io.zell.zdb.v81.Version81Test;
+import io.zell.zdb.v82.Version82Test;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
@@ -65,7 +65,6 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -73,6 +72,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Testcontainers
 public class Version83Test {
 
+    private static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("camunda/zeebe:8.3.0");
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final BpmnModelInstance PROCESS =
@@ -91,6 +91,63 @@ public class Version83Test {
                     .done();
 
     @Nested
+    public class LargeLogTest {
+        // earlier ZDB versions failed on large logs, because of segments were async created and incomplete
+        private static final Logger LOGGER =
+                LoggerFactory.getLogger(LargeLogTest.class);
+        private static final File TEMP_DIR = TestUtils.newTmpFolder(LargeLogTest.class);
+        private static final ZeebeContentCreator zeebeContentCreator = new ZeebeContentCreator(PROCESS);
+        @Container
+        public static ZeebeContainer zeebeContainer = new ZeebeContainer(DOCKER_IMAGE)
+                /* run the container with the current user, in order to access the data and delete it later */
+                .withCreateContainerCmdModifier(cmd -> cmd.withUser(TestUtils.getRunAsUser()))
+                // with 8.2 we disabled WAL per default
+                // we have to enabled it inorder to access the data from RocksDB
+                .withEnv("ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL", "false")
+                .withLogConsumer(new Slf4jLogConsumer(LOGGER))
+                .withFileSystemBind(TEMP_DIR.getPath(), TestUtils.CONTAINER_PATH, BindMode.READ_WRITE);
+
+        static {
+            TEMP_DIR.mkdirs();
+        }
+
+        @BeforeAll
+        public static void setup() {
+            zeebeContentCreator
+                    .createLargeContent(zeebeContainer.getExternalGatewayAddress());
+        }
+
+        @AfterAll
+        public static void cleanup() throws Exception {
+            FileUtil.deleteFolderIfExists(TEMP_DIR.toPath());
+        }
+
+        @Test
+        public void shouldReadStatusFromLog() {
+            // given
+            final var logPath = ZeebePaths.Companion.getLogPath(TEMP_DIR, "1");
+            var logStatus = new LogStatus(logPath);
+
+            // when
+            final var status = logStatus.status();
+
+            // then
+            assertThat(status.getHighestIndex()).isEqualTo(211);
+            assertThat(status.getHighestTerm()).isEqualTo(1);
+            assertThat(status.getHighestRecordPosition()).isEqualTo(258);
+            assertThat(status.getLowestIndex()).isEqualTo(1);
+            assertThat(status.getLowestRecordPosition()).isEqualTo(1);
+
+            assertThat(status.toString())
+                    .contains("lowestRecordPosition")
+                    .contains("highestRecordPosition")
+                    .contains("highestTerm")
+                    .contains("highestIndex")
+                    .contains("lowestIndex");
+        }
+    }
+
+    @Nested
     public class ZeebeLogTest {
 
         private static final Logger LOGGER =
@@ -98,7 +155,7 @@ public class Version83Test {
         private static final File TEMP_DIR = TestUtils.newTmpFolder(ZeebeLogTest.class);
         private static final ZeebeContentCreator zeebeContentCreator = new ZeebeContentCreator(PROCESS);
         @Container
-        public static ZeebeContainer zeebeContainer = new ZeebeContainer(DockerImageName.parse("camunda/zeebe:8.3.0"))
+        public static ZeebeContainer zeebeContainer = new ZeebeContainer(DOCKER_IMAGE)
                 /* run the container with the current user, in order to access the data and delete it later */
                 .withCreateContainerCmdModifier(cmd -> cmd.withUser(TestUtils.getRunAsUser()))
                 // with 8.2 we disabled WAL per default
@@ -716,7 +773,7 @@ public class Version83Test {
         private static final File TEMP_DIR = TestUtils.newTmpFolder(ZeebeStateTest.class);
         private static final ZeebeContentCreator zeebeContentCreator = new ZeebeContentCreator(PROCESS);
         @Container
-        public static ZeebeContainer zeebeContainer = new ZeebeContainer(DockerImageName.parse("camunda/zeebe:8.3.0"))
+        public static ZeebeContainer zeebeContainer = new ZeebeContainer(DOCKER_IMAGE)
                 /* run the container with the current user, in order to access the data and delete it later */
                 .withCreateContainerCmdModifier(cmd -> cmd.withUser(TestUtils.getRunAsUser()))
                 // with 8.2 we disabled WAL per default


### PR DESCRIPTION
Zeebe creates segments async, which are not yet initialized this causes zdb to fail because it expects certain meta data, we will ingore such from now on.

Added tests to reproduce this in different versions.

@deepthidevaki fyi