### PR TITLE
Add Frontend to ZDB

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -42,7 +42,6 @@
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <zeebe-test-container.version>3.6.3</zeebe-test-container.version>
-        <version.slf4j>2.0.13</version.slf4j>
         <version.awaitility>4.2.1</version.awaitility>
         <version.jackson>2.13.0</version.jackson>
         <jackson-databind.version>2.13.0</jackson-databind.version>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+
+    <parent>
+        <groupId>io.zell</groupId>
+        <artifactId>zdb</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>frontend</artifactId>
+    <name>frontend</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.0</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>21</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>21</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.zell</groupId>
+            <artifactId>backend</artifactId>
+            <version>2.4.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${version.slf4j}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <!-- Google code format plugin -->
+            <plugin>
+                <groupId>com.spotify.fmt</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>${plugin.version.fmt}</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>0.0.8</version>
+                <executions>
+                    <execution>
+                        <!-- Default configuration for running with: mvn clean javafx:run -->
+                        <id>default-cli</id>
+                        <configuration>
+                            <mainClass>io.zell.zdb.frontend.ZdbFrontendMain</mainClass>
+                            <launcher>app</launcher>
+                            <jlinkZipName>app</jlinkZipName>
+                            <jlinkImageName>app</jlinkImageName>
+                            <noManPages>true</noManPages>
+                            <stripDebug>true</stripDebug>
+                            <noHeaderFiles>true</noHeaderFiles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.7.1</version>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>io.zell.zdb.frontend.ZdbFrontendMain</mainClass>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/frontend/src/main/java/io/zell/zdb/frontend/LogViewController.java
+++ b/frontend/src/main/java/io/zell/zdb/frontend/LogViewController.java
@@ -26,11 +26,9 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
-import javafx.scene.control.Button;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableView;
-import javafx.scene.control.TextField;
+import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.scene.input.*;
 import javafx.stage.DirectoryChooser;
 
 public class LogViewController implements Initializable {
@@ -74,6 +72,11 @@ public class LogViewController implements Initializable {
             LogViewController.<Integer>createTableColumn("Record\nversion", "recordVersion"),
             LogViewController.<String>createTableColumn("Auth\ndata", "authData"),
             LogViewController.<String>createTableColumn("Record\nvalue", "recordValue"));
+
+    // enable multi-selection
+    this.zeebeData.getSelectionModel().setCellSelectionEnabled(true);
+    this.zeebeData.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+    this.zeebeData.setOnKeyPressed(new TableViewKeyEventClipboardCopier<>(this.zeebeData));
   }
 
   private static <T> TableColumn<ZeebeRecord, T> createTableColumn(

--- a/frontend/src/main/java/io/zell/zdb/frontend/LogViewController.java
+++ b/frontend/src/main/java/io/zell/zdb/frontend/LogViewController.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.frontend;
+
+import io.zell.zdb.log.LogContentReader;
+import io.zell.zdb.log.records.ApplicationRecord;
+import io.zell.zdb.log.records.PersistedRecord;
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.ResourceBundle;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.control.Button;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextField;
+import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.stage.DirectoryChooser;
+
+public class LogViewController implements Initializable {
+
+  @FXML private TableView<ZeebeRecord> zeebeData;
+
+  @FXML private Button findDataPath;
+
+  @FXML private TextField dataPath;
+  private final DirectoryChooser directoryChooser = new DirectoryChooser();
+  private ObservableList<ZeebeRecord> dataObservableList;
+
+  @Override
+  public void initialize(final URL url, final ResourceBundle resourceBundle) {
+    // time to initialize fields
+    final var userHome = System.getProperty("user.home");
+    this.dataPath.setText(userHome);
+
+    this.dataObservableList = FXCollections.observableList(new ArrayList<>());
+    // put into the data table view
+    this.zeebeData.setItems(this.dataObservableList);
+
+    // define columns
+    this.zeebeData
+        .getColumns()
+        .setAll(
+            LogViewController.<Long>createTableColumn("Position", "position"),
+            LogViewController.<Long>createTableColumn(
+                "Source\nRecord\nPosition", "sourceRecordPosition"),
+            LogViewController.<Long>createTableColumn("Timestamp", "timestamp"),
+            LogViewController.<Long>createTableColumn("Key", "key"),
+            LogViewController.<String>createTableColumn("Record\ntype", "recordType"),
+            LogViewController.<String>createTableColumn("Value\ntype", "valueType"),
+            LogViewController.<String>createTableColumn("Intent", "intent"),
+            LogViewController.<String>createTableColumn("Rejection\ntype", "rejectionType"),
+            LogViewController.<String>createTableColumn("Rejection\nreason", "rejectionReason"),
+            LogViewController.<Long>createTableColumn("Request\nID", "requestId"),
+            LogViewController.<Integer>createTableColumn("Request\nstream\nID", "requestStreamId"),
+            LogViewController.<Integer>createTableColumn("Protocol\nversion", "protocolVersion"),
+            LogViewController.<String>createTableColumn("Broker\nversion", "brokerVersion"),
+            LogViewController.<Integer>createTableColumn("Record\nversion", "recordVersion"),
+            LogViewController.<String>createTableColumn("Auth\ndata", "authData"),
+            LogViewController.<String>createTableColumn("Record\nvalue", "recordValue"));
+  }
+
+  private static <T> TableColumn<ZeebeRecord, T> createTableColumn(
+      final String displayName, final String propertyName) {
+    final TableColumn<ZeebeRecord, T> column = new TableColumn<ZeebeRecord, T>(displayName);
+    column.setCellValueFactory(new PropertyValueFactory<ZeebeRecord, T>(propertyName));
+    return column;
+  }
+
+  @FXML
+  protected void onFindFile() {
+    this.directoryChooser.setTitle("Zeebe data path");
+    this.directoryChooser.setInitialDirectory(new File(System.getProperty("user.home")));
+
+    final File file = this.directoryChooser.showDialog(this.findDataPath.getScene().getWindow());
+
+    if (file != null) {
+      this.dataPath.setText(file.getAbsolutePath());
+
+      final var logContentReader = new LogContentReader(new File(this.dataPath.getText()).toPath());
+      while (logContentReader.hasNext()) {
+        final PersistedRecord next = logContentReader.next();
+
+        if (next instanceof final ApplicationRecord applicationRecord) {
+          for (final var r : applicationRecord.getEntries()) {
+            final var zeebeRecord =
+                new ZeebeRecord(
+                    r.getPosition(),
+                    r.getSourceRecordPosition(),
+                    r.getTimestamp(),
+                    r.getKey(),
+                    r.getRecordType().name(),
+                    r.getValueType().name(),
+                    r.getIntent().name(),
+                    r.getRejectionType().name(),
+                    r.getRejectionReason(),
+                    r.getRequestId(),
+                    r.getRequestStreamId(),
+                    r.getProtocolVersion(),
+                    r.getBrokerVersion(),
+                    r.getRecordVersion(),
+                    r.getAuthData(),
+                    r.getRecordValue().toString());
+            this.dataObservableList.add(zeebeRecord);
+          }
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/main/java/io/zell/zdb/frontend/StateViewController.java
+++ b/frontend/src/main/java/io/zell/zdb/frontend/StateViewController.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.frontend;
+
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.zell.zdb.state.KeyFormatters;
+import io.zell.zdb.state.ZeebeDbReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.ResourceBundle;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.control.*;
+import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.stage.DirectoryChooser;
+
+public class StateViewController implements Initializable {
+
+  @FXML private TableView<StateDataKV> zeebeData;
+
+  @FXML private Button findDataPath;
+
+  @FXML private TextField dataPath;
+
+  @FXML private ChoiceBox<String> columnFamily;
+
+  private final DirectoryChooser directoryChooser = new DirectoryChooser();
+  private ObservableList<StateDataKV> dataObservableList;
+
+  @Override
+  public void initialize(final URL url, final ResourceBundle resourceBundle) {
+    // time to initialize fields
+    final var userHome = System.getProperty("user.home");
+    this.dataPath.setText(userHome);
+
+    this.columnFamily.setItems(
+        FXCollections.observableList(
+            Arrays.stream(ZbColumnFamilies.values()).map(Enum::name).toList()));
+    this.columnFamily.setValue(ZbColumnFamilies.DEFAULT.name());
+
+    // put into the data table view
+    this.dataObservableList = FXCollections.observableList(new ArrayList<>());
+    this.zeebeData.setItems(this.dataObservableList);
+    // define columns
+    this.zeebeData.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_ALL_COLUMNS);
+    this.zeebeData
+        .getColumns()
+        .setAll(
+            StateViewController.<String>createTableColumn("Key", "key"),
+            StateViewController.<String>createTableColumn("Value", "value"));
+  }
+
+  private static <T> TableColumn<StateDataKV, T> createTableColumn(
+      final String displayName, final String propertyName) {
+    final TableColumn<StateDataKV, T> column = new TableColumn<StateDataKV, T>(displayName);
+    column.setCellValueFactory(new PropertyValueFactory<StateDataKV, T>(propertyName));
+    return column;
+  }
+
+  public class StateDataKV {
+    private final StringProperty key;
+    private final StringProperty value;
+
+    public StateDataKV(final String key, final String value) {
+      this.key = new SimpleStringProperty(key);
+      this.value = new SimpleStringProperty(value);
+    }
+
+    public String getKey() {
+      return this.key.get();
+    }
+
+    public StringProperty keyProperty() {
+      return this.key;
+    }
+
+    public void setKey(final String key) {
+      this.key.set(key);
+    }
+
+    public String getValue() {
+      return this.value.get();
+    }
+
+    public StringProperty valueProperty() {
+      return this.value;
+    }
+
+    public void setValue(final String value) {
+      this.value.set(value);
+    }
+  }
+
+  @FXML
+  protected void onFindFile() {
+    this.directoryChooser.setTitle("Zeebe data path");
+    this.directoryChooser.setInitialDirectory(new File(System.getProperty("user.home")));
+
+    final File file = this.directoryChooser.showDialog(this.findDataPath.getScene().getWindow());
+
+    if (file != null) {
+      this.dataPath.setText(file.getAbsolutePath());
+      fillTableViewWithStateData(this.dataPath.getText(), this.columnFamily.getValue());
+    }
+  }
+
+  private void fillTableViewWithStateData(final String path, final String columnFamilyName) {
+    // read data based on column family
+    final var zeebeDbReader = new ZeebeDbReader(new File(path).toPath());
+    final var columnFamilyValue = ZbColumnFamilies.valueOf(columnFamilyName);
+
+    final var keyFormatter = KeyFormatters.ofDefault().forColumnFamily(columnFamilyValue);
+
+    // remove old content
+    this.dataObservableList.clear();
+    this.zeebeData.setColumnResizePolicy(TableView.UNCONSTRAINED_RESIZE_POLICY);
+    // update table view
+    zeebeDbReader.visitDBWithPrefix(
+        columnFamilyValue,
+        (key, value) ->
+            this.dataObservableList.add(new StateDataKV(keyFormatter.formatKey(key), value)));
+  }
+
+  public void selectColumnFamily() {
+    // do something on selecting CF
+    try {
+      final var expectedPath = this.dataPath.getText();
+
+      fillTableViewWithStateData(expectedPath, this.columnFamily.getValue());
+    } catch (final Exception exception) {
+      if (exception instanceof FileNotFoundException) {
+        // no state path
+        System.out.println(
+            String.format(
+                "Current path %s doesn't point to a state path.", this.dataPath.getText()));
+        return;
+      }
+      exception.printStackTrace();
+    }
+  }
+}

--- a/frontend/src/main/java/io/zell/zdb/frontend/StateViewController.java
+++ b/frontend/src/main/java/io/zell/zdb/frontend/StateViewController.java
@@ -32,6 +32,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.scene.input.*;
 import javafx.stage.DirectoryChooser;
 
 public class StateViewController implements Initializable {
@@ -52,6 +53,7 @@ public class StateViewController implements Initializable {
     // time to initialize fields
     final var userHome = System.getProperty("user.home");
     this.dataPath.setText(userHome);
+    this.dataPath.setEditable(false);
 
     this.columnFamily.setItems(
         FXCollections.observableList(
@@ -68,6 +70,11 @@ public class StateViewController implements Initializable {
         .setAll(
             StateViewController.<String>createTableColumn("Key", "key"),
             StateViewController.<String>createTableColumn("Value", "value"));
+
+    // enable multi-selection
+    this.zeebeData.getSelectionModel().setCellSelectionEnabled(true);
+    this.zeebeData.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+    this.zeebeData.setOnKeyPressed(new TableViewKeyEventClipboardCopier<>(this.zeebeData));
   }
 
   private static <T> TableColumn<StateDataKV, T> createTableColumn(

--- a/frontend/src/main/java/io/zell/zdb/frontend/TableViewKeyEventClipboardCopier.java
+++ b/frontend/src/main/java/io/zell/zdb/frontend/TableViewKeyEventClipboardCopier.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.frontend;
+
+import javafx.collections.ObservableList;
+import javafx.event.EventHandler;
+import javafx.scene.control.TablePosition;
+import javafx.scene.control.TableView;
+import javafx.scene.input.*;
+
+public class TableViewKeyEventClipboardCopier<T extends KeyEvent> implements EventHandler<T> {
+
+  public static final KeyCodeCombination KEY_CODE_COMBINATION_COPY =
+      new KeyCodeCombination(KeyCode.C, KeyCombination.CONTROL_ANY);
+  private final TableView tableView;
+
+  public TableViewKeyEventClipboardCopier(final TableView tableView) {
+    this.tableView = tableView;
+  }
+
+  @Override
+  public void handle(final T keyEvent) {
+    if (KEY_CODE_COMBINATION_COPY.match(keyEvent)) {
+      if (keyEvent.getSource() instanceof TableView) {
+        final var clipboard = Clipboard.getSystemClipboard();
+        final var content = new ClipboardContent();
+
+        final ObservableList<TablePosition> selectedCells =
+            this.tableView.getSelectionModel().getSelectedCells();
+
+        for (final var position : selectedCells) {
+          final var value = position.getTableColumn().getCellObservableValue(position.getRow());
+          final String valueStr = value.getValue().toString();
+          System.out.println(valueStr);
+          content.putString(valueStr);
+        }
+        clipboard.setContent(content);
+        System.out.println("Selection copied to clipboard");
+
+        // event is handled, consume it
+        keyEvent.consume();
+      }
+    }
+  }
+}

--- a/frontend/src/main/java/io/zell/zdb/frontend/ZdbApplication.java
+++ b/frontend/src/main/java/io/zell/zdb/frontend/ZdbApplication.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
+import javafx.scene.input.*;
 import javafx.stage.Stage;
 
 public class ZdbApplication extends Application {

--- a/frontend/src/main/java/io/zell/zdb/frontend/ZdbApplication.java
+++ b/frontend/src/main/java/io/zell/zdb/frontend/ZdbApplication.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.frontend;
+
+import java.io.IOException;
+import javafx.application.Application;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+public class ZdbApplication extends Application {
+  @Override
+  public void start(final Stage stage) throws IOException {
+    final FXMLLoader fxmlLoader = new FXMLLoader(ZdbApplication.class.getResource("zdb-view.fxml"));
+    final Scene scene = new Scene(fxmlLoader.load(), 320, 240);
+    stage.setTitle("Zeebe debug and inspection tool");
+    stage.setScene(scene);
+    stage.show();
+  }
+
+  public static void main(final String[] args) {
+    launch();
+  }
+}

--- a/frontend/src/main/java/io/zell/zdb/frontend/ZdbFrontendMain.java
+++ b/frontend/src/main/java/io/zell/zdb/frontend/ZdbFrontendMain.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.frontend;
+
+public class ZdbFrontendMain {
+
+  public static void main(String[] args) {
+    ZdbApplication.main(args);
+  }
+}

--- a/frontend/src/main/java/io/zell/zdb/frontend/ZeebeRecord.java
+++ b/frontend/src/main/java/io/zell/zdb/frontend/ZeebeRecord.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.frontend;
+
+import javafx.beans.property.*;
+
+public class ZeebeRecord {
+  //                        Record(val position: Long,
+  //                                val sourceRecordPosition: Long,
+  //                                val timestamp: Long,
+  //                                val key: Long,
+  //                                val recordType: RecordType,
+  //                                val valueType: ValueType,
+  //                                @Serializable(with = IntentSerializer::class)
+  //                                        val intent: Intent,
+  //                                val rejectionType: RejectionType? = RejectionType.NULL_VAL,
+  //                                val rejectionReason: String? = "",
+  //                                val requestId: Long? = 0,
+  //                                val requestStreamId: Int = 0,
+  //                                val protocolVersion: Int,
+  //                                val brokerVersion: String,
+  //                                val recordVersion: Int ? = 0,
+  //                                val authData: String ? = "",
+  //                                val recordValue: JsonElement,
+  //                                /*Transient marks to ignore the property during serialization */
+  //                                @Transient val piRelatedValue: ProcessInstanceRelatedValue? =
+  // null
+  private final LongProperty position;
+  private final LongProperty sourceRecordPosition;
+  private final LongProperty timestamp;
+  private final LongProperty key;
+  private final StringProperty recordType;
+  private final StringProperty ValueType;
+  private final StringProperty intent;
+
+  private final StringProperty rejectionType;
+  private final StringProperty rejectionReason;
+  private final LongProperty requestId;
+  private final IntegerProperty requestStreamId;
+  private final IntegerProperty protocolVersion;
+  private final StringProperty brokerVersion;
+  private final IntegerProperty recordVersion;
+  private final StringProperty authData;
+  private final StringProperty recordValue;
+
+  public ZeebeRecord(
+      final long position,
+      final long sourceRecordPostion,
+      final long timestamp,
+      final long key,
+      final String recordType,
+      final String valueType,
+      final String intent,
+      final String rejectionType,
+      final String rejectionReason,
+      final long requestId,
+      final int requestStreamId,
+      final int protocolVersion,
+      final String brokerVersion,
+      final int recordVersion,
+      final String authData,
+      final String recordValue) {
+    this.position = new SimpleLongProperty(position);
+    this.sourceRecordPosition = new SimpleLongProperty(sourceRecordPostion);
+    this.timestamp = new SimpleLongProperty(timestamp);
+    this.key = new SimpleLongProperty(key);
+    this.recordType = new SimpleStringProperty(recordType);
+    this.ValueType = new SimpleStringProperty(valueType);
+    this.intent = new SimpleStringProperty(intent);
+    this.rejectionType = new SimpleStringProperty(rejectionType);
+    this.rejectionReason = new SimpleStringProperty(rejectionReason);
+    this.requestId = new SimpleLongProperty(requestId);
+    this.requestStreamId = new SimpleIntegerProperty(requestStreamId);
+    this.protocolVersion = new SimpleIntegerProperty(protocolVersion);
+    this.brokerVersion = new SimpleStringProperty(brokerVersion);
+    this.recordVersion = new SimpleIntegerProperty(recordVersion);
+    this.authData = new SimpleStringProperty(authData);
+    this.recordValue = new SimpleStringProperty(recordValue);
+  }
+
+  public String getRejectionType() {
+    return this.rejectionType.get();
+  }
+
+  public StringProperty rejectionTypeProperty() {
+    return this.rejectionType;
+  }
+
+  public void setRejectionType(final String rejectionType) {
+    this.rejectionType.set(rejectionType);
+  }
+
+  public String getRejectionReason() {
+    return this.rejectionReason.get();
+  }
+
+  public StringProperty rejectionReasonProperty() {
+    return this.rejectionReason;
+  }
+
+  public void setRejectionReason(final String rejectionReason) {
+    this.rejectionReason.set(rejectionReason);
+  }
+
+  public long getRequestId() {
+    return this.requestId.get();
+  }
+
+  public LongProperty requestIdProperty() {
+    return this.requestId;
+  }
+
+  public void setRequestId(final long requestId) {
+    this.requestId.set(requestId);
+  }
+
+  public int getRequestStreamId() {
+    return this.requestStreamId.get();
+  }
+
+  public IntegerProperty requestStreamIdProperty() {
+    return this.requestStreamId;
+  }
+
+  public void setRequestStreamId(final int requestStreamId) {
+    this.requestStreamId.set(requestStreamId);
+  }
+
+  public int getProtocolVersion() {
+    return this.protocolVersion.get();
+  }
+
+  public IntegerProperty protocolVersionProperty() {
+    return this.protocolVersion;
+  }
+
+  public void setProtocolVersion(final int protocolVersion) {
+    this.protocolVersion.set(protocolVersion);
+  }
+
+  public String getBrokerVersion() {
+    return this.brokerVersion.get();
+  }
+
+  public StringProperty brokerVersionProperty() {
+    return this.brokerVersion;
+  }
+
+  public void setBrokerVersion(final String brokerVersion) {
+    this.brokerVersion.set(brokerVersion);
+  }
+
+  public int getRecordVersion() {
+    return this.recordVersion.get();
+  }
+
+  public IntegerProperty recordVersionProperty() {
+    return this.recordVersion;
+  }
+
+  public void setRecordVersion(final int recordVersion) {
+    this.recordVersion.set(recordVersion);
+  }
+
+  public String getAuthData() {
+    return this.authData.get();
+  }
+
+  public StringProperty authDataProperty() {
+    return this.authData;
+  }
+
+  public void setAuthData(final String authData) {
+    this.authData.set(authData);
+  }
+
+  public String getRecordValue() {
+    return this.recordValue.get();
+  }
+
+  public StringProperty recordValueProperty() {
+    return this.recordValue;
+  }
+
+  public void setRecordValue(final String recordValue) {
+    this.recordValue.set(recordValue);
+  }
+
+  public long getPosition() {
+    return this.position.get();
+  }
+
+  public LongProperty positionProperty() {
+    return this.position;
+  }
+
+  public void setPosition(final long position) {
+    this.position.set(position);
+  }
+
+  public long getSourceRecordPosition() {
+    return this.sourceRecordPosition.get();
+  }
+
+  public LongProperty sourceRecordPositionProperty() {
+    return this.sourceRecordPosition;
+  }
+
+  public void setSourceRecordPosition(final long sourceRecordPosition) {
+    this.sourceRecordPosition.set(sourceRecordPosition);
+  }
+
+  public long getTimestamp() {
+    return this.timestamp.get();
+  }
+
+  public LongProperty timestampProperty() {
+    return this.timestamp;
+  }
+
+  public void setTimestamp(final long timestamp) {
+    this.timestamp.set(timestamp);
+  }
+
+  public long getKey() {
+    return this.key.get();
+  }
+
+  public LongProperty keyProperty() {
+    return this.key;
+  }
+
+  public void setKey(final long key) {
+    this.key.set(key);
+  }
+
+  public String getRecordType() {
+    return this.recordType.get();
+  }
+
+  public StringProperty recordTypeProperty() {
+    return this.recordType;
+  }
+
+  public void setRecordType(final String recordType) {
+    this.recordType.set(recordType);
+  }
+
+  public String getValueType() {
+    return this.ValueType.get();
+  }
+
+  public StringProperty valueTypeProperty() {
+    return this.ValueType;
+  }
+
+  public void setValueType(final String valueType) {
+    this.ValueType.set(valueType);
+  }
+
+  public String getIntent() {
+    return this.intent.get();
+  }
+
+  public StringProperty intentProperty() {
+    return this.intent;
+  }
+
+  public void setIntent(final String intent) {
+    this.intent.set(intent);
+  }
+}

--- a/frontend/src/main/resources/io/zell/zdb/frontend/log-view.fxml
+++ b/frontend/src/main/resources/io/zell/zdb/frontend/log-view.fxml
@@ -16,10 +16,13 @@
         <Button fx:id="findDataPath" text="Find Data path" onAction="#onFindFile"/>
     </HBox>
 
-    <HBox>
+    <HBox alignment="CENTER" spacing="20.0">
         <Text text="Instance key: "/>
-        <TextField fx:id="instanceKey"/>
-        <Button fx:id="findInstanceKey" text="Find" onAction="#onFindInstanceKey"/>
+        <TextField fx:id="instanceKey" onAction="#findLog"/>
+        <Text text="From: "/>
+        <TextField fx:id="fromPosition" onKeyPressed="#findLog"/>
+        <Text text="To: "/>
+        <TextField fx:id="toPosition" onKeyPressed="#findLog"/>
     </HBox>
     <TableView fx:id="zeebeData"/>
 </VBox>

--- a/frontend/src/main/resources/io/zell/zdb/frontend/log-view.fxml
+++ b/frontend/src/main/resources/io/zell/zdb/frontend/log-view.fxml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.TableView?>
-<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.*?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.text.Text?>
 <VBox alignment="CENTER" spacing="20.0" xmlns:fx="http://javafx.com/fxml"
       fx:controller="io.zell.zdb.frontend.LogViewController">
     <padding>
@@ -17,5 +16,10 @@
         <Button fx:id="findDataPath" text="Find Data path" onAction="#onFindFile"/>
     </HBox>
 
+    <HBox>
+        <Text text="Instance key: "/>
+        <TextField fx:id="instanceKey"/>
+        <Button fx:id="findInstanceKey" text="Find" onAction="#onFindInstanceKey"/>
+    </HBox>
     <TableView fx:id="zeebeData"/>
 </VBox>

--- a/frontend/src/main/resources/io/zell/zdb/frontend/log-view.fxml
+++ b/frontend/src/main/resources/io/zell/zdb/frontend/log-view.fxml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+<VBox alignment="CENTER" spacing="20.0" xmlns:fx="http://javafx.com/fxml"
+      fx:controller="io.zell.zdb.frontend.LogViewController">
+    <padding>
+        <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>
+    </padding>
+
+    <HBox>
+        <TextField fx:id="dataPath"/>
+        <Button fx:id="findDataPath" text="Find Data path" onAction="#onFindFile"/>
+    </HBox>
+
+    <TableView fx:id="zeebeData"/>
+</VBox>

--- a/frontend/src/main/resources/io/zell/zdb/frontend/state-view.fxml
+++ b/frontend/src/main/resources/io/zell/zdb/frontend/state-view.fxml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ChoiceBox?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+<VBox alignment="CENTER" spacing="20.0" xmlns:fx="http://javafx.com/fxml"
+      fx:controller="io.zell.zdb.frontend.StateViewController">
+    <padding>
+        <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>
+    </padding>
+
+    <HBox>
+        <TextField fx:id="dataPath"/>
+        <Button fx:id="findDataPath" text="Find Data path" onAction="#onFindFile"/>
+        <ChoiceBox fx:id="columnFamily" onAction="#selectColumnFamily"/>
+    </HBox>
+
+    <TableView fx:id="zeebeData"/>
+</VBox>

--- a/frontend/src/main/resources/io/zell/zdb/frontend/zdb-view.fxml
+++ b/frontend/src/main/resources/io/zell/zdb/frontend/zdb-view.fxml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Tab?>
+<?import javafx.scene.control.TabPane?>
+<?import javafx.scene.layout.VBox?>
+<VBox spacing="20.0" xmlns:fx="http://javafx.com/fxml">
+    <TabPane>
+        <Tab fx:id="logTab" text="Log">
+            <fx:include source="log-view.fxml"/>
+        </Tab>
+        <Tab fx:id="stateTab" text="State">
+            <fx:include source="state-view.fxml"/>
+        </Tab>
+    </TabPane>
+</VBox>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
     <modules>
         <module>backend</module>
         <module>cli</module>
+        <module>frontend</module>
     </modules>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <plugin.version.checkstyle>3.3.1</plugin.version.checkstyle>
         <plugin.version.fmt>2.23</plugin.version.fmt>
+        <version.slf4j>2.0.13</version.slf4j>
         <plugin.version.license>4.5</plugin.version.license>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.guava>30.0-jre</version.guava>


### PR DESCRIPTION

Adds frontend (JavaFX based) to ZDB that allows to investigate the log, with similar feature as printing the log via zdb cli

![log-view](https://github.com/Zelldon/zdb/assets/2758593/d4519f55-62a9-40d0-b625-668df47eeabb)

Furthermore, it allows to investigate the state with all existing column families. It uses the key formatter functionally recently added to ZDB to correctly print the keys. All values are printed as JSON values.

![state](https://github.com/Zelldon/zdb/assets/2758593/fab04f22-f7af-48b8-bbc8-9d50d626d454)
