### PR TITLE
Convert given CF names

### DIFF
--- a/cli/src/main/java/io/zell/zdb/state/StateCommand.java
+++ b/cli/src/main/java/io/zell/zdb/state/StateCommand.java
@@ -78,7 +78,7 @@ public class StateCommand implements Callable<Integer> {
                               valueJson));
                     }));
               } else {
-                final var cf = ZbColumnFamilies.valueOf(columnFamilyName);
+                final var cf = ZbColumnFamilies.valueOf(columnFamilyName.toUpperCase());
                 zeebeDbReader.visitDBWithPrefix(
                     cf,
                     ((key, valueJson) ->

--- a/cli/src/main/java/io/zell/zdb/state/StateCommand.java
+++ b/cli/src/main/java/io/zell/zdb/state/StateCommand.java
@@ -41,7 +41,7 @@ public class StateCommand implements Callable<Integer> {
 
   @Override
   public Integer call() {
-    final var jsonString = new ZeebeDbReader(partitionPath).stateStatisticsAsJsonString();
+    final var jsonString = new ZeebeDbReader(this.partitionPath).stateStatisticsAsJsonString();
     System.out.println(jsonString);
     return 0;
   }
@@ -64,7 +64,7 @@ public class StateCommand implements Callable<Integer> {
     new JsonPrinter()
         .surround(
             (printer) -> {
-              final var zeebeDbReader = new ZeebeDbReader(partitionPath);
+              final var zeebeDbReader = new ZeebeDbReader(this.partitionPath);
               // we print incrementally in order to avoid to build up big state in the application
               if (noColumnFamilyGiven(columnFamilyName)) {
                 zeebeDbReader.visitDBWithJsonValues(
@@ -93,7 +93,7 @@ public class StateCommand implements Callable<Integer> {
     return 0;
   }
 
-  private KeyFormatters chooseKeyFormatters(String keyFormat) {
+  private KeyFormatters chooseKeyFormatters(final String keyFormat) {
     return switch (keyFormat) {
       case "default", "" -> KeyFormatters.ofDefault();
       case null -> KeyFormatters.ofDefault();
@@ -102,7 +102,7 @@ public class StateCommand implements Callable<Integer> {
     };
   }
 
-  private static boolean noColumnFamilyGiven(String columnFamilyName) {
+  private static boolean noColumnFamilyGiven(final String columnFamilyName) {
     return columnFamilyName == null || columnFamilyName.isEmpty();
   }
 }


### PR DESCRIPTION
To allow small column family names
```
 ./zdb state list -cf key -p raft-partition/partitions/1/snapshots/15-1-38-53/
{"data":[java.lang.IllegalArgumentException: No enum constant io.camunda.zeebe.protocol.ZbColumnFamilies.key
	at java.base/java.lang.Enum.valueOf(Enum.java:293)
	at io.camunda.zeebe.protocol.ZbColumnFamilies.valueOf(ZbColumnFamilies.java:18)
	at io.zell.zdb.state.StateCommand.lambda$list$2(StateCommand.java:81)
	at io.zell.zdb.JsonPrinter.surround(JsonPrinter.java:60)
	at io.zell.zdb.state.StateCommand.list(StateCommand.java:65)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2070)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
	at picocli.CommandLine.execute(CommandLine.java:2174)
	at io.zell.zdb.ZeebeDebugger.main(ZeebeDebugger.java:62)

```