### PR TITLE
fix: err fallback on key formatting

### DIFF
--- a/backend/src/main/kotlin/io/zell/zdb/state/KeyFormatter.java
+++ b/backend/src/main/kotlin/io/zell/zdb/state/KeyFormatter.java
@@ -65,25 +65,29 @@ public interface KeyFormatter {
       final var formatted = new StringBuilder();
       final var keyBuffer = new UnsafeBuffer(key);
       int offset = 8;
-      for (final var dbValue : this.values) {
-        dbValue.wrap(keyBuffer, offset, key.length - offset);
-        offset += dbValue.getLength();
-        if (!formatted.isEmpty()) {
-          formatted.append(":");
-        }
-        switch (dbValue) {
-          case final DbString dbString -> formatted.append(dbString);
-          case final DbLong dbLong -> formatted.append(dbLong.getValue());
-          case final DbInt dbInt -> formatted.append(dbInt.getValue());
-          case final DbByte dbByte -> formatted.append(dbByte.getValue());
-          case final DbBytes dbBytes -> {
-            final var buf = dbBytes.getDirectBuffer();
-            final var bytes = new byte[dbBytes.getLength()];
-            buf.getBytes(0, bytes);
-            formatted.append(KeyFormatters.HEX_FORMATTER.formatKey(bytes));
+      try {
+        for (final var dbValue : this.values) {
+          dbValue.wrap(keyBuffer, offset, key.length - offset);
+          offset += dbValue.getLength();
+          if (!formatted.isEmpty()) {
+            formatted.append(":");
           }
-          default -> formatted.append(dbValue);
+          switch (dbValue) {
+            case final DbString dbString -> formatted.append(dbString);
+            case final DbLong dbLong -> formatted.append(dbLong.getValue());
+            case final DbInt dbInt -> formatted.append(dbInt.getValue());
+            case final DbByte dbByte -> formatted.append(dbByte.getValue());
+            case final DbBytes dbBytes -> {
+              final var buf = dbBytes.getDirectBuffer();
+              final var bytes = new byte[dbBytes.getLength()];
+              buf.getBytes(0, bytes);
+              formatted.append(KeyFormatters.HEX_FORMATTER.formatKey(bytes));
+            }
+            default -> formatted.append(dbValue);
+          }
         }
+      } catch (final IndexOutOfBoundsException indexOutOfBoundsException) {
+        return KeyFormatters.HEX_FORMATTER.formatKey(key);
       }
       return formatted.toString();
     }


### PR DESCRIPTION
If an keyformatter is wrong previously zdb failed with IndexOutOfBounce exceptions. This commit allows to still print the key in hex format, to handle errors more gracefully

For example on printing the state it previously failed with:

```
{"cf":"PROCESS_CACHE_DIGEST_BY_ID","key":"<default>:Process_04inzbr","value":{"digest":"R6Fk39sgsbKmot1FTKZ3Cg=="}}java.lang.IndexOutOfBoundsException: index=41 length=524288 capacity=58
	at org.agrona.AbstractMutableDirectBuffer.boundsCheck0(AbstractMutableDirectBuffer.java:1719)
	at org.agrona.AbstractMutableDirectBuffer.getBytes(AbstractMutableDirectBuffer.java:450)
	at io.camunda.zeebe.db.impl.DbString.wrap(DbString.java:37)
	at io.zell.zdb.state.KeyFormatter$DbValueFormatter.formatKey(KeyFormatter.java:69)
	at io.zell.zdb.state.StateCommand.lambda$list$0(StateCommand.java:77)
	at io.zell.zdb.state.ZeebeDbReader.visitDBWithJsonValues$lambda$3(ZeebeDbReader.kt:145)
	at io.zell.zdb.state.ZeebeDbReader.visitDB(ZeebeDbReader.kt:136)
	at io.zell.zdb.state.ZeebeDbReader.visitDBWithJsonValues(ZeebeDbReader.kt:143)
	at io.zell.zdb.state.StateCommand.lambda$list$2(StateCommand.java:70)
	at io.zell.zdb.JsonPrinter.surround(JsonPrinter.java:60)
	at io.zell.zdb.state.StateCommand.list(StateCommand.java:65)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2070)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
	at picocli.CommandLine.execute(CommandLine.java:2174)
	at io.zell.zdb.ZeebeDebugger.main(ZeebeDebugger.java:62)

```

Now it would fallback to hex decoding at least:

```
{"cf":"PROCESS_CACHE_DIGEST_BY_ID","key":"<default>:run-release","value":{"digest":"GCddNRa/G9InIBsRIviw9w=="}},
{"cf":"PROCESS_CACHE_DIGEST_BY_ID","key":"<default>:Process_04inzbr","value":{"digest":"R6Fk39sgsbKmot1FTKZ3Cg=="}},
{"cf":"JOB_ACTIVATABLE","key":"00 00 00 00 00 00 00 4c 00 00 00 19 69 6f 2e 63 61 6d 75 6e 64 61 2e 7a 65 65 62 65 3a 75 73 65 72 54 61 73 6b 00 08 00 00 00 00 00 10 00 00 00 09 3c 64 65 66 61 75 6c 74 3e","value":-1}]}
```