### PR TITLE
fix: move testcontainers dependency from compile to test scope

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -298,7 +298,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <scope>compile</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
## Summary

- `testcontainers` was declared with `compile` scope in `backend/pom.xml` but is not used in any production source
- This caused it to be bundled into the fat JAR artifact unnecessarily (~5–10 MB overhead)
- Moved to `test` scope so it is excluded from the production artifact

## Test plan

- [ ] Verify tests still pass (testcontainers is only used in test code)
- [ ] Verify the fat JAR in `cli/target` is smaller after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)