### PR TITLE
[Draft]: Adding MCP Server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,132 @@
+# zdb — Zeebe Debug & Inspection Tool
+
+zdb reads Zeebe (Camunda 8) partition data from disk: the embedded RocksDB
+runtime state, the segmented Raft log, and the raft meta/config files. It is a
+read-only, offline tool intended for debugging customer incidents from a copy
+of a broker's data folder.
+
+## Module structure
+
+This is a Maven multi-module project (Java 21, Kotlin backend, JavaFX
+frontend):
+
+- `backend/` — Kotlin library exposing the readers (`io.zell.zdb.*`):
+  state (`IncidentState`, `InstanceState`, `ProcessState`, `ZeebeDbReader`),
+  log (`LogStatus`, `LogSearch`, `LogContentReader`), raft (`RaftStatus`),
+  and the `ZeebePaths` helper for resolving `<data>/raft-partition/...`.
+- `cli/` — picocli-based CLI (`io.zell.zdb.ZeebeDebugger`) that wraps the
+  backend readers as subcommands.
+- `frontend/` — JavaFX desktop UI.
+- `mcp-server/` — Model Context Protocol server (`io.zell.zdb.mcp.ZdbMcpServer`)
+  that exposes the backend readers as MCP tools so an LLM (Claude) can analyse
+  customer partition data locally.
+
+## Building
+
+Always run from the repo root.
+
+```sh
+mvn package -DskipTests        # quick build, all modules
+mvn verify                      # full build + tests (Testcontainers required)
+mvn package -pl mcp-server -am -DskipTests   # MCP server only
+```
+
+The CLI assembly produces `cli/target/cli-<version>-jar-with-dependencies.jar`
+and the MCP server produces `mcp-server/target/zdb-mcp-jar-with-dependencies.jar`.
+
+## Running the CLI
+
+```sh
+./zdb --path <partition-path> <command>
+```
+
+`<partition-path>` points at the partition directory (e.g.
+`<data>/raft-partition/partitions/1`). Available subcommands include
+`incident`, `instance`, `process`, `log`, `raft`, and `state`.
+
+## Running the MCP server
+
+```sh
+mvn package -pl mcp-server -am -DskipTests
+./zdb-mcp
+```
+
+The script execs the assembled jar with stdio; the server speaks MCP over
+stdin/stdout.
+
+### Configuring Claude Code
+
+Add an entry to `~/.claude/mcp_servers.json` (or whatever Claude Code config
+you use):
+
+```json
+{
+  "mcpServers": {
+    "zdb": {
+      "command": "/absolute/path/to/zdb/zdb-mcp"
+    }
+  }
+}
+```
+
+### Tools exposed
+
+12 read-only tools, all returning JSON text content:
+
+- `list_partitions(data_path)` — discover partition dirs under a Zeebe data
+  folder. Always call this first.
+- `get_partition_status(partition_path)` — combined log+raft summary.
+- `list_processes`, `get_process` — deployed process definitions.
+- `list_process_instances`, `get_process_instance` — running instances.
+- `list_incidents`, `get_incident` — active incidents (filterable by
+  `error_type`, `bpmn_process_id`, `process_definition_key`).
+- `get_log_status`, `search_log_by_position`, `search_log_by_index`,
+  `list_log_records` — Raft log inspection.
+- `list_column_families` — RocksDB column family row counts.
+
+Pagination envelopes: `{"total_fetched":N,"offset":O,"limit":L,"has_more":B,"data":[...]}`.
+
+## Backend API quick reference
+
+State readers take the **runtime** path (`<part>/runtime`). Log/raft readers
+take the **partition** path (`<part>`). Use `io.zell.zdb.ZeebePaths.getRuntimePath`
+and `getLogPath` to construct them, or `io.zell.zdb.mcp.util.PathResolver`
+inside the MCP server (which falls back to the latest snapshot if no live
+runtime exists).
+
+Key visitor types:
+
+- `JsonElementVisitor#visit(String json)` — used by `IncidentState.listIncidents`.
+- `ZeebeDbReader.JsonValueWithKeyPrefixVisitor#visit(byte[] key, String json)`
+  — used by `InstanceState.listProcessInstances`, `ProcessState.listProcesses`,
+  etc.
+
+## Tests
+
+- Tests use **Testcontainers** with `io.zeebe:zeebe-test-container` to spin up
+  a real Zeebe (Camunda 8) broker, mount its data dir to the host, deploy a
+  workload, then run readers against the resulting RocksDB / log files.
+- `backend/src/test/kotlin/io/zell/zdb/TestUtils.java` provides
+  `createZeebeContainerGreaterOrEquals88(...)` for 8.8+ images and
+  `createZeebeContainerBefore85(...)` for older images. The MCP server test
+  inlines its own container setup to avoid pulling in test scope from
+  `backend`.
+- Per-version test classes live in `backend/src/test/kotlin/io/zell/zdb/v8x/`.
+
+## Zeebe data layout
+
+```
+<data>/                                    # what users mount/copy
+  raft-partition/
+    partitions/
+      1/                                   # partition dir (numeric name)
+        runtime/                           # live RocksDB state
+        snapshots/<position>-<term>/       # snapshot RocksDB state
+        raft-partition-partition-1.meta    # raft meta
+        raft-partition-partition-1.conf    # raft config
+        raft-partition-partition-1-1.log   # raft log segment(s)
+```
+
+The MCP `partition_path` argument always refers to the `partitions/<id>/`
+directory (not the runtime). State tools resolve the runtime internally; log
+and raft tools take the partition dir directly.

--- a/mcp-server/pom.xml
+++ b/mcp-server/pom.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.zell</groupId>
+        <artifactId>zdb</artifactId>
+        <version>2.7.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mcp-server</artifactId>
+    <name>ZDB MCP Server</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <mcp.version>1.1.2</mcp.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.zell</groupId>
+            <artifactId>backend</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp-core</artifactId>
+            <version>${mcp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp-json-jackson2</artifactId>
+            <version>${mcp.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.zeebe</groupId>
+            <artifactId>zeebe-test-container</artifactId>
+            <version>${zeebe-test-container.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Google code format plugin -->
+            <plugin>
+                <groupId>com.spotify.fmt</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>${plugin.version.fmt}</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- CHECKSTYLE -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${plugin.version.checkstyle}</version>
+                <!-- dependency on build tool to reference the checkstyle cfg -->
+                <dependencies>
+                    <dependency>
+                        <groupId>io.camunda</groupId>
+                        <artifactId>zeebe-build-tools</artifactId>
+                        <version>${bom.version.zeebe}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <configLocation>check/.checkstyle.xml</configLocation>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <encoding>UTF-8</encoding>
+                    <failOnViolation>true</failOnViolation>
+                    <sourceDirectories>
+                        <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                        <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+                    </sourceDirectories>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate-java</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven-assembly-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>zdb-mcp</finalName>
+                            <appendAssemblyId>true</appendAssemblyId>
+                            <archive>
+                                <manifest>
+                                    <mainClass>io.zell.zdb.mcp.ZdbMcpServer</mainClass>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.5</version>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mcp-server/src/main/java/io/zell/zdb/mcp/ZdbMcpServer.java
+++ b/mcp-server/src/main/java/io/zell/zdb/mcp/ZdbMcpServer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.mcp;
+
+import io.modelcontextprotocol.json.McpJsonDefaults;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
+import io.zell.zdb.mcp.tools.ColumnFamilyTools;
+import io.zell.zdb.mcp.tools.IncidentTools;
+import io.zell.zdb.mcp.tools.LogTools;
+import io.zell.zdb.mcp.tools.PartitionTools;
+import io.zell.zdb.mcp.tools.ProcessInstanceTools;
+import io.zell.zdb.mcp.tools.ProcessTools;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Entry point for the zdb MCP server. Reads/writes JSON-RPC messages over stdio and exposes the zdb
+ * backend's read-only inspection capabilities as MCP tools.
+ */
+public final class ZdbMcpServer {
+
+  private static final String SERVER_NAME = "zdb-mcp";
+  private static final String SERVER_VERSION = "2.7.0";
+
+  private ZdbMcpServer() {}
+
+  public static void main(final String[] args) throws InterruptedException {
+    final StdioServerTransportProvider transport =
+        new StdioServerTransportProvider(McpJsonDefaults.getMapper());
+
+    final List<McpServerFeatures.SyncToolSpecification> tools = new ArrayList<>();
+    tools.addAll(PartitionTools.specs());
+    tools.addAll(ProcessTools.specs());
+    tools.addAll(ProcessInstanceTools.specs());
+    tools.addAll(IncidentTools.specs());
+    tools.addAll(LogTools.specs());
+    tools.addAll(ColumnFamilyTools.specs());
+
+    final McpSyncServer server =
+        McpServer.sync(transport)
+            .serverInfo(SERVER_NAME, SERVER_VERSION)
+            .capabilities(ServerCapabilities.builder().tools(true).build())
+            .tools(tools)
+            .build();
+
+    // Keep the JVM alive while the stdio transport is running.
+    try {
+      Thread.currentThread().join();
+    } finally {
+      server.close();
+    }
+  }
+}

--- a/mcp-server/src/main/java/io/zell/zdb/mcp/tools/ColumnFamilyTools.java
+++ b/mcp-server/src/main/java/io/zell/zdb/mcp/tools/ColumnFamilyTools.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.mcp.tools;
+
+import static io.zell.zdb.mcp.util.ToolUtils.error;
+import static io.zell.zdb.mcp.util.ToolUtils.ok;
+import static io.zell.zdb.mcp.util.ToolUtils.requiredString;
+
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import io.zell.zdb.mcp.util.PathResolver;
+import io.zell.zdb.state.ZeebeDbReader;
+import java.util.List;
+import java.util.Map;
+
+/** MCP tool specifications for inspecting RocksDB column family statistics. */
+public final class ColumnFamilyTools {
+
+  private ColumnFamilyTools() {}
+
+  public static List<McpServerFeatures.SyncToolSpecification> specs() {
+    return List.of(listColumnFamilies());
+  }
+
+  private static McpServerFeatures.SyncToolSpecification listColumnFamilies() {
+    final JsonSchema schema =
+        new JsonSchema(
+            "object",
+            Map.of(
+                "partition_path",
+                Map.of(
+                    "type",
+                    "string",
+                    "description",
+                    "Path to a partition directory as returned by list_partitions.")),
+            List.of("partition_path"),
+            false,
+            null,
+            null);
+
+    final Tool tool =
+        Tool.builder()
+            .name("list_column_families")
+            .description(
+                "Returns row counts per RocksDB column family. Useful for understanding "
+                    + "partition state volume. Does not return full data — just counts. To "
+                    + "inspect data in a specific column family, use the state commands.")
+            .inputSchema(schema)
+            .build();
+
+    return McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool)
+        .callHandler(
+            (exchange, request) -> {
+              try {
+                final Map<String, Object> args = request.arguments();
+                final String partitionPath = requiredString(args, "partition_path");
+                return ok(listColumnFamiliesImpl(partitionPath));
+              } catch (final Exception e) {
+                return error(e);
+              }
+            })
+        .build();
+  }
+
+  static String listColumnFamiliesImpl(final String partitionPath) {
+    return new ZeebeDbReader(PathResolver.runtimePath(partitionPath)).stateStatisticsAsJsonString();
+  }
+
+  /** Direct test entrypoint. */
+  public static CallToolResult listColumnFamiliesCall(final String partitionPath) {
+    try {
+      return ok(listColumnFamiliesImpl(partitionPath));
+    } catch (final Exception e) {
+      return error(e);
+    }
+  }
+}

--- a/mcp-server/src/main/java/io/zell/zdb/mcp/tools/IncidentTools.java
+++ b/mcp-server/src/main/java/io/zell/zdb/mcp/tools/IncidentTools.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.mcp.tools;
+
+import static io.zell.zdb.mcp.util.ToolUtils.MAPPER;
+import static io.zell.zdb.mcp.util.ToolUtils.error;
+import static io.zell.zdb.mcp.util.ToolUtils.intOrDefault;
+import static io.zell.zdb.mcp.util.ToolUtils.ok;
+import static io.zell.zdb.mcp.util.ToolUtils.optionalLong;
+import static io.zell.zdb.mcp.util.ToolUtils.optionalString;
+import static io.zell.zdb.mcp.util.ToolUtils.requiredLong;
+import static io.zell.zdb.mcp.util.ToolUtils.requiredString;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import io.zell.zdb.mcp.util.PaginatedResult;
+import io.zell.zdb.mcp.util.PathResolver;
+import io.zell.zdb.state.incident.IncidentState;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** MCP tool specifications for inspecting incidents. */
+public final class IncidentTools {
+
+  private static final int DEFAULT_LIMIT = 50;
+  private static final int MAX_LIMIT = 500;
+
+  private IncidentTools() {}
+
+  public static List<McpServerFeatures.SyncToolSpecification> specs() {
+    return List.of(listIncidents(), getIncident());
+  }
+
+  private static McpServerFeatures.SyncToolSpecification listIncidents() {
+    final JsonSchema schema =
+        new JsonSchema(
+            "object",
+            Map.of(
+                "partition_path",
+                    Map.of(
+                        "type", "string",
+                        "description",
+                            "Path to a partition directory as returned by list_partitions."),
+                "error_type",
+                    Map.of(
+                        "type",
+                        "string",
+                        "description",
+                        "Optional error type filter (e.g. JOB_NO_RETRIES, "
+                            + "EXTRACT_VALUE_ERROR, CALLED_ELEMENT_ERROR, "
+                            + "UNHANDLED_ERROR_EVENT, MESSAGE_SIZE_EXCEEDED)."),
+                "bpmn_process_id",
+                    Map.of(
+                        "type", "string",
+                        "description", "Optional BPMN process ID filter (exact match)."),
+                "process_definition_key",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Optional processDefinitionKey filter (exact match)."),
+                "limit",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Maximum number of items per page. Default 50, max 500."),
+                "offset",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Number of items to skip. Default 0.")),
+            List.of("partition_path"),
+            false,
+            null,
+            null);
+
+    final Tool tool =
+        Tool.builder()
+            .name("list_incidents")
+            .description(
+                "Lists all active incidents in the partition. Filter by error_type "
+                    + "(e.g. JOB_NO_RETRIES, EXTRACT_VALUE_ERROR, CALLED_ELEMENT_ERROR, "
+                    + "UNHANDLED_ERROR_EVENT, MESSAGE_SIZE_EXCEEDED), bpmn_process_id, or "
+                    + "process_definition_key. Use limit/offset to paginate. Start with a "
+                    + "small limit to understand the volume.")
+            .inputSchema(schema)
+            .build();
+
+    return McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool)
+        .callHandler(
+            (exchange, request) -> {
+              try {
+                final Map<String, Object> args = request.arguments();
+                final String partitionPath = requiredString(args, "partition_path");
+                final String errorType = optionalString(args, "error_type");
+                final String bpmnProcessId = optionalString(args, "bpmn_process_id");
+                final Long processDefinitionKey = optionalLong(args, "process_definition_key");
+                final int limit = Math.min(MAX_LIMIT, intOrDefault(args, "limit", DEFAULT_LIMIT));
+                final int offset = intOrDefault(args, "offset", 0);
+                return ok(
+                    listIncidentsImpl(
+                        partitionPath,
+                        errorType,
+                        bpmnProcessId,
+                        processDefinitionKey,
+                        offset,
+                        limit));
+              } catch (final Exception e) {
+                return error(e);
+              }
+            })
+        .build();
+  }
+
+  static String listIncidentsImpl(
+      final String partitionPath,
+      final String errorType,
+      final String bpmnProcessId,
+      final Long processDefinitionKey,
+      final int offset,
+      final int limit) {
+    final Path runtime = PathResolver.runtimePath(partitionPath);
+    final List<String> items = new ArrayList<>();
+    new IncidentState(runtime)
+        .listIncidents(
+            jsonElement -> {
+              if (matchesFilters(jsonElement, errorType, bpmnProcessId, processDefinitionKey)) {
+                items.add(jsonElement);
+              }
+            });
+    return PaginatedResult.buildPageJson(items, offset, limit);
+  }
+
+  private static boolean matchesFilters(
+      final String incidentJson,
+      final String errorType,
+      final String bpmnProcessId,
+      final Long processDefinitionKey) {
+    if (errorType == null && bpmnProcessId == null && processDefinitionKey == null) {
+      return true;
+    }
+    try {
+      final JsonNode root = MAPPER.readTree(incidentJson);
+      final JsonNode value = root.path("value");
+      if (errorType != null && !errorType.equals(value.path("errorType").asText(null))) {
+        return false;
+      }
+      if (bpmnProcessId != null
+          && !bpmnProcessId.equals(value.path("bpmnProcessId").asText(null))) {
+        return false;
+      }
+      if (processDefinitionKey != null) {
+        final JsonNode pdk = value.path("processDefinitionKey");
+        if (!pdk.isNumber() || pdk.asLong() != processDefinitionKey) {
+          return false;
+        }
+      }
+      return true;
+    } catch (final Exception e) {
+      return false;
+    }
+  }
+
+  private static McpServerFeatures.SyncToolSpecification getIncident() {
+    final JsonSchema schema =
+        new JsonSchema(
+            "object",
+            Map.of(
+                "partition_path",
+                    Map.of(
+                        "type", "string",
+                        "description",
+                            "Path to a partition directory as returned by list_partitions."),
+                "incident_key",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Incident key.")),
+            List.of("partition_path", "incident_key"),
+            false,
+            null,
+            null);
+
+    final Tool tool =
+        Tool.builder()
+            .name("get_incident")
+            .description("Returns full details of a specific incident by key.")
+            .inputSchema(schema)
+            .build();
+
+    return McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool)
+        .callHandler(
+            (exchange, request) -> {
+              try {
+                final Map<String, Object> args = request.arguments();
+                final String partitionPath = requiredString(args, "partition_path");
+                final long incidentKey = requiredLong(args, "incident_key");
+                return ok(getIncidentImpl(partitionPath, incidentKey));
+              } catch (final Exception e) {
+                return error(e);
+              }
+            })
+        .build();
+  }
+
+  static String getIncidentImpl(final String partitionPath, final long incidentKey) {
+    final Path runtime = PathResolver.runtimePath(partitionPath);
+    return new IncidentState(runtime).incidentDetails(incidentKey);
+  }
+
+  /** Direct test entrypoint. */
+  public static CallToolResult listIncidentsCall(
+      final String partitionPath,
+      final String errorType,
+      final String bpmnProcessId,
+      final Long processDefinitionKey,
+      final int offset,
+      final int limit) {
+    try {
+      return ok(
+          listIncidentsImpl(
+              partitionPath, errorType, bpmnProcessId, processDefinitionKey, offset, limit));
+    } catch (final Exception e) {
+      return error(e);
+    }
+  }
+
+  /** Direct test entrypoint. */
+  public static CallToolResult getIncidentCall(final String partitionPath, final long incidentKey) {
+    try {
+      return ok(getIncidentImpl(partitionPath, incidentKey));
+    } catch (final Exception e) {
+      return error(e);
+    }
+  }
+}

--- a/mcp-server/src/main/java/io/zell/zdb/mcp/tools/LogTools.java
+++ b/mcp-server/src/main/java/io/zell/zdb/mcp/tools/LogTools.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.mcp.tools;
+
+import static io.zell.zdb.mcp.util.ToolUtils.error;
+import static io.zell.zdb.mcp.util.ToolUtils.intOrDefault;
+import static io.zell.zdb.mcp.util.ToolUtils.ok;
+import static io.zell.zdb.mcp.util.ToolUtils.optionalLong;
+import static io.zell.zdb.mcp.util.ToolUtils.requiredLong;
+import static io.zell.zdb.mcp.util.ToolUtils.requiredString;
+
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import io.zell.zdb.log.LogContentReader;
+import io.zell.zdb.log.LogSearch;
+import io.zell.zdb.log.LogStatus;
+import io.zell.zdb.log.records.PersistedRecord;
+import io.zell.zdb.mcp.util.PaginatedResult;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** MCP tool specifications for inspecting the Raft log. */
+public final class LogTools {
+
+  private static final int DEFAULT_LIMIT = 20;
+  private static final int MAX_LIMIT = 200;
+
+  private LogTools() {}
+
+  public static List<McpServerFeatures.SyncToolSpecification> specs() {
+    return List.of(getLogStatus(), searchLogByPosition(), searchLogByIndex(), listLogRecords());
+  }
+
+  private static McpServerFeatures.SyncToolSpecification getLogStatus() {
+    final JsonSchema schema =
+        new JsonSchema(
+            "object",
+            Map.of(
+                "partition_path",
+                Map.of(
+                    "type",
+                    "string",
+                    "description",
+                    "Path to a partition directory as returned by list_partitions.")),
+            List.of("partition_path"),
+            false,
+            null,
+            null);
+
+    final Tool tool =
+        Tool.builder()
+            .name("get_log_status")
+            .description(
+                "Returns log statistics: position range, index range, and highest term. "
+                    + "Use this to understand what data is in the log before using "
+                    + "list_log_records or search_log_by_position.")
+            .inputSchema(schema)
+            .build();
+
+    return McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool)
+        .callHandler(
+            (exchange, request) -> {
+              try {
+                final Map<String, Object> args = request.arguments();
+                final String partitionPath = requiredString(args, "partition_path");
+                return ok(getLogStatusImpl(partitionPath));
+              } catch (final Exception e) {
+                return error(e);
+              }
+            })
+        .build();
+  }
+
+  static String getLogStatusImpl(final String partitionPath) {
+    return new LogStatus(Paths.get(partitionPath)).status().toString();
+  }
+
+  private static McpServerFeatures.SyncToolSpecification searchLogByPosition() {
+    final JsonSchema schema =
+        new JsonSchema(
+            "object",
+            Map.of(
+                "partition_path",
+                    Map.of(
+                        "type", "string",
+                        "description",
+                            "Path to a partition directory as returned by list_partitions."),
+                "position",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Application-level position (ASQN) to look up.")),
+            List.of("partition_path", "position"),
+            false,
+            null,
+            null);
+
+    final Tool tool =
+        Tool.builder()
+            .name("search_log_by_position")
+            .description(
+                "Finds a specific log record by application-level position (ASQN). "
+                    + "Returns the full record including intent, value type, and record "
+                    + "value. Use get_log_status first to find valid position ranges.")
+            .inputSchema(schema)
+            .build();
+
+    return McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool)
+        .callHandler(
+            (exchange, request) -> {
+              try {
+                final Map<String, Object> args = request.arguments();
+                final String partitionPath = requiredString(args, "partition_path");
+                final long position = requiredLong(args, "position");
+                return ok(searchLogByPositionImpl(partitionPath, position));
+              } catch (final Exception e) {
+                return error(e);
+              }
+            })
+        .build();
+  }
+
+  static String searchLogByPositionImpl(final String partitionPath, final long position) {
+    final var record = new LogSearch(Paths.get(partitionPath)).searchPosition(position);
+    return record == null ? "null" : record.toString();
+  }
+
+  private static McpServerFeatures.SyncToolSpecification searchLogByIndex() {
+    final JsonSchema schema =
+        new JsonSchema(
+            "object",
+            Map.of(
+                "partition_path",
+                    Map.of(
+                        "type", "string",
+                        "description",
+                            "Path to a partition directory as returned by list_partitions."),
+                "index",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Raft log index to look up.")),
+            List.of("partition_path", "index"),
+            false,
+            null,
+            null);
+
+    final Tool tool =
+        Tool.builder()
+            .name("search_log_by_index")
+            .description(
+                "Finds a log entry by raft index (may be an ApplicationRecord or a "
+                    + "RaftRecord). Use get_log_status to find valid index ranges.")
+            .inputSchema(schema)
+            .build();
+
+    return McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool)
+        .callHandler(
+            (exchange, request) -> {
+              try {
+                final Map<String, Object> args = request.arguments();
+                final String partitionPath = requiredString(args, "partition_path");
+                final long index = requiredLong(args, "index");
+                return ok(searchLogByIndexImpl(partitionPath, index));
+              } catch (final Exception e) {
+                return error(e);
+              }
+            })
+        .build();
+  }
+
+  static String searchLogByIndexImpl(final String partitionPath, final long index) {
+    final var record = new LogSearch(Paths.get(partitionPath)).searchIndex(index);
+    return record == null ? "null" : record.toString();
+  }
+
+  private static McpServerFeatures.SyncToolSpecification listLogRecords() {
+    final JsonSchema schema =
+        new JsonSchema(
+            "object",
+            Map.of(
+                "partition_path",
+                    Map.of(
+                        "type", "string",
+                        "description",
+                            "Path to a partition directory as returned by list_partitions."),
+                "from_position",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Optional starting position (ASQN) for the scan."),
+                "to_position",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Optional ending position (ASQN) for the scan (exclusive)."),
+                "process_instance_key",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Optional process instance key filter."),
+                "limit",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Maximum number of items per page. Default 20, max 200."),
+                "offset",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Number of items to skip. Default 0.")),
+            List.of("partition_path"),
+            false,
+            null,
+            null);
+
+    final Tool tool =
+        Tool.builder()
+            .name("list_log_records")
+            .description(
+                "Streams log records with optional filters. WARNING: the log can be very "
+                    + "large (millions of records). Always use from_position/to_position or "
+                    + "process_instance_key to narrow the range, and start with a small "
+                    + "limit (10-20). Each record includes position, intent, valueType, "
+                    + "key, and recordValue. Consider using search_log_by_position or "
+                    + "search_log_by_index for point lookups instead.")
+            .inputSchema(schema)
+            .build();
+
+    return McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool)
+        .callHandler(
+            (exchange, request) -> {
+              try {
+                final Map<String, Object> args = request.arguments();
+                final String partitionPath = requiredString(args, "partition_path");
+                final Long fromPosition = optionalLong(args, "from_position");
+                final Long toPosition = optionalLong(args, "to_position");
+                final Long processInstanceKey = optionalLong(args, "process_instance_key");
+                final int limit = Math.min(MAX_LIMIT, intOrDefault(args, "limit", DEFAULT_LIMIT));
+                final int offset = intOrDefault(args, "offset", 0);
+                return ok(
+                    listLogRecordsImpl(
+                        partitionPath,
+                        fromPosition,
+                        toPosition,
+                        processInstanceKey,
+                        offset,
+                        limit));
+              } catch (final Exception e) {
+                return error(e);
+              }
+            })
+        .build();
+  }
+
+  static String listLogRecordsImpl(
+      final String partitionPath,
+      final Long fromPosition,
+      final Long toPosition,
+      final Long processInstanceKey,
+      final int offset,
+      final int limit) {
+    final Path partDir = Paths.get(partitionPath);
+    final LogContentReader reader = new LogContentReader(partDir);
+    if (fromPosition != null) {
+      reader.seekToPosition(fromPosition);
+    }
+    if (toPosition != null) {
+      reader.limitToPosition(toPosition);
+    }
+    if (processInstanceKey != null) {
+      reader.filterForProcessInstance(processInstanceKey);
+    }
+
+    final int safeOffset = Math.max(0, offset);
+    final int safeLimit = Math.max(0, limit);
+    final int cap = safeOffset + safeLimit;
+    final List<String> collected = new ArrayList<>();
+    int collectedCount = 0;
+    while (reader.hasNext() && collectedCount < cap) {
+      final PersistedRecord record = reader.next();
+      collected.add(record.toString());
+      collectedCount++;
+    }
+
+    return PaginatedResult.buildPageJson(collected, safeOffset, safeLimit);
+  }
+
+  /** Direct test entrypoint. */
+  public static CallToolResult getLogStatusCall(final String partitionPath) {
+    try {
+      return ok(getLogStatusImpl(partitionPath));
+    } catch (final Exception e) {
+      return error(e);
+    }
+  }
+
+  /** Direct test entrypoint. */
+  public static CallToolResult searchLogByPositionCall(
+      final String partitionPath, final long position) {
+    try {
+      return ok(searchLogByPositionImpl(partitionPath, position));
+    } catch (final Exception e) {
+      return error(e);
+    }
+  }
+
+  /** Direct test entrypoint. */
+  public static CallToolResult searchLogByIndexCall(final String partitionPath, final long index) {
+    try {
+      return ok(searchLogByIndexImpl(partitionPath, index));
+    } catch (final Exception e) {
+      return error(e);
+    }
+  }
+
+  /** Direct test entrypoint. */
+  public static CallToolResult listLogRecordsCall(
+      final String partitionPath,
+      final Long fromPosition,
+      final Long toPosition,
+      final Long processInstanceKey,
+      final int offset,
+      final int limit) {
+    try {
+      return ok(
+          listLogRecordsImpl(
+              partitionPath, fromPosition, toPosition, processInstanceKey, offset, limit));
+    } catch (final Exception e) {
+      return error(e);
+    }
+  }
+}

--- a/mcp-server/src/main/java/io/zell/zdb/mcp/tools/PartitionTools.java
+++ b/mcp-server/src/main/java/io/zell/zdb/mcp/tools/PartitionTools.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.mcp.tools;
+
+import static io.zell.zdb.mcp.util.ToolUtils.MAPPER;
+import static io.zell.zdb.mcp.util.ToolUtils.error;
+import static io.zell.zdb.mcp.util.ToolUtils.ok;
+import static io.zell.zdb.mcp.util.ToolUtils.requiredString;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import io.zell.zdb.log.LogStatus;
+import io.zell.zdb.raft.RaftStatus;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/** MCP tool specifications for discovering and inspecting partition directories. */
+public final class PartitionTools {
+
+  private PartitionTools() {}
+
+  /**
+   * @return all partition-discovery and partition-status tool specs.
+   */
+  public static List<McpServerFeatures.SyncToolSpecification> specs() {
+    return List.of(listPartitions(), getPartitionStatus());
+  }
+
+  private static McpServerFeatures.SyncToolSpecification listPartitions() {
+    final JsonSchema schema =
+        new JsonSchema(
+            "object",
+            Map.of(
+                "data_path",
+                Map.of(
+                    "type", "string",
+                    "description",
+                        "The root Zeebe data directory (the parent of raft-partition).")),
+            List.of("data_path"),
+            false,
+            null,
+            null);
+
+    final Tool tool =
+        Tool.builder()
+            .name("list_partitions")
+            .description(
+                "Discovers Zeebe partition directories under the given data path. Returns "
+                    + "partition IDs and their full paths. Always call this first before "
+                    + "using other tools — use the returned partition_path values for all "
+                    + "subsequent calls. Typical Zeebe data structure: "
+                    + "<data_path>/raft-partition/partitions/<id>/.")
+            .inputSchema(schema)
+            .build();
+
+    return McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool)
+        .callHandler(
+            (exchange, request) -> {
+              try {
+                final Map<String, Object> args = request.arguments();
+                final String dataPath = requiredString(args, "data_path");
+                return ok(listPartitionsImpl(dataPath));
+              } catch (final Exception e) {
+                return error(e);
+              }
+            })
+        .build();
+  }
+
+  static String listPartitionsImpl(final String dataPath) throws IOException {
+    final Path partitionsDir = Paths.get(dataPath, "raft-partition", "partitions");
+    final ArrayNode array = MAPPER.createArrayNode();
+
+    if (!Files.isDirectory(partitionsDir)) {
+      final ObjectNode result = MAPPER.createObjectNode();
+      result.put("data_path", dataPath);
+      result.put("partitions_dir", partitionsDir.toString());
+      result.put("exists", false);
+      result.set("partitions", array);
+      return result.toString();
+    }
+
+    try (Stream<Path> stream = Files.list(partitionsDir)) {
+      stream
+          .filter(Files::isDirectory)
+          .filter(p -> isNumeric(p.getFileName().toString()))
+          .sorted(Comparator.comparingInt(p -> Integer.parseInt(p.getFileName().toString())))
+          .forEach(
+              p -> {
+                final ObjectNode entry = MAPPER.createObjectNode();
+                final String id = p.getFileName().toString();
+                entry.put("id", Integer.parseInt(id));
+                entry.put("partition_path", p.toAbsolutePath().toString());
+                final Path runtime = p.resolve("runtime");
+                final boolean hasRuntime = Files.isDirectory(runtime);
+                entry.put("has_runtime", hasRuntime);
+                entry.put("runtime_path", runtime.toAbsolutePath().toString());
+                entry.put("snapshot_count", countSnapshots(p));
+                array.add(entry);
+              });
+    }
+
+    final ObjectNode result = MAPPER.createObjectNode();
+    result.put("data_path", dataPath);
+    result.put("partitions_dir", partitionsDir.toString());
+    result.put("exists", true);
+    result.set("partitions", array);
+    return result.toString();
+  }
+
+  private static int countSnapshots(final Path partitionDir) {
+    final Path snapshots = partitionDir.resolve("snapshots");
+    if (!Files.isDirectory(snapshots)) {
+      return 0;
+    }
+    try (Stream<Path> stream = Files.list(snapshots)) {
+      return (int) stream.filter(Files::isDirectory).count();
+    } catch (final IOException e) {
+      return 0;
+    }
+  }
+
+  private static boolean isNumeric(final String s) {
+    if (s == null || s.isEmpty()) {
+      return false;
+    }
+    for (int i = 0; i < s.length(); i++) {
+      if (!Character.isDigit(s.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static McpServerFeatures.SyncToolSpecification getPartitionStatus() {
+    final JsonSchema schema =
+        new JsonSchema(
+            "object",
+            Map.of(
+                "partition_path",
+                Map.of(
+                    "type",
+                    "string",
+                    "description",
+                    "Path to a partition directory as returned by list_partitions.")),
+            List.of("partition_path"),
+            false,
+            null,
+            null);
+
+    final Tool tool =
+        Tool.builder()
+            .name("get_partition_status")
+            .description(
+                "Returns the current log and raft status of a partition. Useful as a first "
+                    + "step to understand partition health: position range, index range, "
+                    + "term, and cluster configuration.")
+            .inputSchema(schema)
+            .build();
+
+    return McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool)
+        .callHandler(
+            (exchange, request) -> {
+              try {
+                final Map<String, Object> args = request.arguments();
+                final String partitionPath = requiredString(args, "partition_path");
+                return ok(getPartitionStatusImpl(partitionPath));
+              } catch (final Exception e) {
+                return error(e);
+              }
+            })
+        .build();
+  }
+
+  static String getPartitionStatusImpl(final String partitionPath) {
+    final Path partDir = Paths.get(partitionPath);
+    final String log = new LogStatus(partDir).status().toString();
+    final String raft = new RaftStatus(partDir).detailsAsJson();
+    return "{\"log\":" + log + ",\"raft\":" + raft + "}";
+  }
+
+  /** Helper returning a thunk that wraps the result-or-error logic for unit tests. */
+  public static CallToolResult listPartitionsCall(final String dataPath) {
+    try {
+      return ok(listPartitionsImpl(dataPath));
+    } catch (final Exception e) {
+      return error(e);
+    }
+  }
+
+  /** Helper returning a thunk that wraps the result-or-error logic for unit tests. */
+  public static CallToolResult getPartitionStatusCall(final String partitionPath) {
+    try {
+      return ok(getPartitionStatusImpl(partitionPath));
+    } catch (final Exception e) {
+      return error(e);
+    }
+  }
+}

--- a/mcp-server/src/main/java/io/zell/zdb/mcp/tools/ProcessInstanceTools.java
+++ b/mcp-server/src/main/java/io/zell/zdb/mcp/tools/ProcessInstanceTools.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.mcp.tools;
+
+import static io.zell.zdb.mcp.util.ToolUtils.error;
+import static io.zell.zdb.mcp.util.ToolUtils.intOrDefault;
+import static io.zell.zdb.mcp.util.ToolUtils.ok;
+import static io.zell.zdb.mcp.util.ToolUtils.optionalLong;
+import static io.zell.zdb.mcp.util.ToolUtils.optionalString;
+import static io.zell.zdb.mcp.util.ToolUtils.requiredLong;
+import static io.zell.zdb.mcp.util.ToolUtils.requiredString;
+
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import io.zell.zdb.mcp.util.PaginatedResult;
+import io.zell.zdb.mcp.util.PathResolver;
+import io.zell.zdb.state.instance.InstanceState;
+import io.zell.zdb.state.instance.ProcessInstanceRecordDetails;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/** MCP tool specifications for inspecting process instances. */
+public final class ProcessInstanceTools {
+
+  private static final int DEFAULT_LIMIT = 50;
+  private static final int MAX_LIMIT = 500;
+
+  private ProcessInstanceTools() {}
+
+  public static List<McpServerFeatures.SyncToolSpecification> specs() {
+    return List.of(listProcessInstances(), getProcessInstance());
+  }
+
+  private static McpServerFeatures.SyncToolSpecification listProcessInstances() {
+    final JsonSchema schema =
+        new JsonSchema(
+            "object",
+            Map.of(
+                "partition_path",
+                    Map.of(
+                        "type", "string",
+                        "description",
+                            "Path to a partition directory as returned by list_partitions."),
+                "bpmn_process_id",
+                    Map.of(
+                        "type", "string",
+                        "description", "Optional BPMN process ID filter (exact match)."),
+                "process_definition_key",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Optional processDefinitionKey filter (exact match)."),
+                "limit",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Maximum number of items per page. Default 50, max 500."),
+                "offset",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Number of items to skip. Default 0.")),
+            List.of("partition_path"),
+            false,
+            null,
+            null);
+
+    final Tool tool =
+        Tool.builder()
+            .name("list_process_instances")
+            .description(
+                "Lists process instances (root process level only, not sub-elements). "
+                    + "Filter by bpmn_process_id or process_definition_key to narrow "
+                    + "results. Use limit/offset to paginate. Each result includes "
+                    + "processInstanceKey, bpmnProcessId, state, and processDefinitionKey.")
+            .inputSchema(schema)
+            .build();
+
+    return McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool)
+        .callHandler(
+            (exchange, request) -> {
+              try {
+                final Map<String, Object> args = request.arguments();
+                final String partitionPath = requiredString(args, "partition_path");
+                final String bpmnProcessId = optionalString(args, "bpmn_process_id");
+                final Long processDefinitionKey = optionalLong(args, "process_definition_key");
+                final int limit = Math.min(MAX_LIMIT, intOrDefault(args, "limit", DEFAULT_LIMIT));
+                final int offset = intOrDefault(args, "offset", 0);
+                return ok(
+                    listProcessInstancesImpl(
+                        partitionPath, bpmnProcessId, processDefinitionKey, offset, limit));
+              } catch (final Exception e) {
+                return error(e);
+              }
+            })
+        .build();
+  }
+
+  static String listProcessInstancesImpl(
+      final String partitionPath,
+      final String bpmnProcessId,
+      final Long processDefinitionKey,
+      final int offset,
+      final int limit) {
+    final Path runtime = PathResolver.runtimePath(partitionPath);
+    final Predicate<ProcessInstanceRecordDetails> predicate =
+        details -> {
+          if (bpmnProcessId != null && !bpmnProcessId.equals(details.getBpmnProcessId())) {
+            return false;
+          }
+          if (processDefinitionKey != null
+              && processDefinitionKey != details.getProcessDefinitionKey()) {
+            return false;
+          }
+          return true;
+        };
+
+    final List<String> items = new ArrayList<>();
+    new InstanceState(runtime)
+        .listProcessInstances(predicate, (key, valueJson) -> items.add(valueJson));
+    return PaginatedResult.buildPageJson(items, offset, limit);
+  }
+
+  private static McpServerFeatures.SyncToolSpecification getProcessInstance() {
+    final JsonSchema schema =
+        new JsonSchema(
+            "object",
+            Map.of(
+                "partition_path",
+                    Map.of(
+                        "type", "string",
+                        "description",
+                            "Path to a partition directory as returned by list_partitions."),
+                "element_instance_key",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Element instance key (process instance or sub-element).")),
+            List.of("partition_path", "element_instance_key"),
+            false,
+            null,
+            null);
+
+    final Tool tool =
+        Tool.builder()
+            .name("get_process_instance")
+            .description(
+                "Returns full details of a specific element instance (process or "
+                    + "sub-element) by its key. Returns child counts, states, and the full "
+                    + "element record.")
+            .inputSchema(schema)
+            .build();
+
+    return McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool)
+        .callHandler(
+            (exchange, request) -> {
+              try {
+                final Map<String, Object> args = request.arguments();
+                final String partitionPath = requiredString(args, "partition_path");
+                final long key = requiredLong(args, "element_instance_key");
+                return ok(getProcessInstanceImpl(partitionPath, key));
+              } catch (final Exception e) {
+                return error(e);
+              }
+            })
+        .build();
+  }
+
+  static String getProcessInstanceImpl(final String partitionPath, final long key) {
+    final Path runtime = PathResolver.runtimePath(partitionPath);
+    return new InstanceState(runtime).getInstance(key);
+  }
+
+  /** Direct test entrypoint. */
+  public static CallToolResult listProcessInstancesCall(
+      final String partitionPath,
+      final String bpmnProcessId,
+      final Long processDefinitionKey,
+      final int offset,
+      final int limit) {
+    try {
+      return ok(
+          listProcessInstancesImpl(
+              partitionPath, bpmnProcessId, processDefinitionKey, offset, limit));
+    } catch (final Exception e) {
+      return error(e);
+    }
+  }
+
+  /** Direct test entrypoint. */
+  public static CallToolResult getProcessInstanceCall(final String partitionPath, final long key) {
+    try {
+      return ok(getProcessInstanceImpl(partitionPath, key));
+    } catch (final Exception e) {
+      return error(e);
+    }
+  }
+}

--- a/mcp-server/src/main/java/io/zell/zdb/mcp/tools/ProcessTools.java
+++ b/mcp-server/src/main/java/io/zell/zdb/mcp/tools/ProcessTools.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.mcp.tools;
+
+import static io.zell.zdb.mcp.util.ToolUtils.error;
+import static io.zell.zdb.mcp.util.ToolUtils.intOrDefault;
+import static io.zell.zdb.mcp.util.ToolUtils.ok;
+import static io.zell.zdb.mcp.util.ToolUtils.requiredLong;
+import static io.zell.zdb.mcp.util.ToolUtils.requiredString;
+
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import io.zell.zdb.mcp.util.PaginatedResult;
+import io.zell.zdb.mcp.util.PathResolver;
+import io.zell.zdb.state.process.ProcessState;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** MCP tool specifications for inspecting deployed process definitions. */
+public final class ProcessTools {
+
+  private static final int DEFAULT_LIMIT = 50;
+  private static final int MAX_LIMIT = 500;
+
+  private ProcessTools() {}
+
+  public static List<McpServerFeatures.SyncToolSpecification> specs() {
+    return List.of(listProcesses(), getProcess());
+  }
+
+  private static McpServerFeatures.SyncToolSpecification listProcesses() {
+    final JsonSchema schema =
+        new JsonSchema(
+            "object",
+            Map.of(
+                "partition_path",
+                    Map.of(
+                        "type", "string",
+                        "description",
+                            "Path to a partition directory as returned by list_partitions."),
+                "limit",
+                    Map.of(
+                        "type",
+                        "integer",
+                        "description",
+                        "Maximum number of items per page. Default 50, max 500."),
+                "offset",
+                    Map.of(
+                        "type", "integer",
+                        "description", "Number of items to skip. Default 0.")),
+            List.of("partition_path"),
+            false,
+            null,
+            null);
+
+    final Tool tool =
+        Tool.builder()
+            .name("list_processes")
+            .description(
+                "Lists deployed process definitions in the partition. Use limit/offset to "
+                    + "paginate. Returns process key, BPMN process ID, version, and "
+                    + "resource name. To investigate a specific process, use get_process "
+                    + "with the processDefinitionKey.")
+            .inputSchema(schema)
+            .build();
+
+    return McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool)
+        .callHandler(
+            (exchange, request) -> {
+              try {
+                final Map<String, Object> args = request.arguments();
+                final String partitionPath = requiredString(args, "partition_path");
+                final int limit = Math.min(MAX_LIMIT, intOrDefault(args, "limit", DEFAULT_LIMIT));
+                final int offset = intOrDefault(args, "offset", 0);
+                return ok(listProcessesImpl(partitionPath, offset, limit));
+              } catch (final Exception e) {
+                return error(e);
+              }
+            })
+        .build();
+  }
+
+  static String listProcessesImpl(final String partitionPath, final int offset, final int limit) {
+    final Path runtime = PathResolver.runtimePath(partitionPath);
+    final List<String> items = new ArrayList<>();
+    new ProcessState(runtime).listProcesses((key, valueJson) -> items.add(valueJson));
+    return PaginatedResult.buildPageJson(items, offset, limit);
+  }
+
+  private static McpServerFeatures.SyncToolSpecification getProcess() {
+    final JsonSchema schema =
+        new JsonSchema(
+            "object",
+            Map.of(
+                "partition_path",
+                    Map.of(
+                        "type", "string",
+                        "description",
+                            "Path to a partition directory as returned by list_partitions."),
+                "process_definition_key",
+                    Map.of(
+                        "type", "integer",
+                        "description", "The processDefinitionKey of the process to fetch.")),
+            List.of("partition_path", "process_definition_key"),
+            false,
+            null,
+            null);
+
+    final Tool tool =
+        Tool.builder()
+            .name("get_process")
+            .description(
+                "Returns full details of a specific process definition, including BPMN "
+                    + "XML. The BPMN resource may be large — consider using list_processes "
+                    + "first to identify the key.")
+            .inputSchema(schema)
+            .build();
+
+    return McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool)
+        .callHandler(
+            (exchange, request) -> {
+              try {
+                final Map<String, Object> args = request.arguments();
+                final String partitionPath = requiredString(args, "partition_path");
+                final long key = requiredLong(args, "process_definition_key");
+                return ok(getProcessImpl(partitionPath, key));
+              } catch (final Exception e) {
+                return error(e);
+              }
+            })
+        .build();
+  }
+
+  static String getProcessImpl(final String partitionPath, final long processDefinitionKey) {
+    final Path runtime = PathResolver.runtimePath(partitionPath);
+    final List<String> matches = new ArrayList<>();
+    new ProcessState(runtime)
+        .processDetails(processDefinitionKey, (key, valueJson) -> matches.add(valueJson));
+    if (matches.isEmpty()) {
+      return "null";
+    }
+    if (matches.size() == 1) {
+      return matches.get(0);
+    }
+    final StringBuilder sb = new StringBuilder("[");
+    for (int i = 0; i < matches.size(); i++) {
+      if (i > 0) {
+        sb.append(",");
+      }
+      sb.append(matches.get(i));
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+
+  /** Direct test entrypoint. */
+  public static CallToolResult listProcessesCall(
+      final String partitionPath, final int offset, final int limit) {
+    try {
+      return ok(listProcessesImpl(partitionPath, offset, limit));
+    } catch (final Exception e) {
+      return error(e);
+    }
+  }
+
+  /** Direct test entrypoint. */
+  public static CallToolResult getProcessCall(
+      final String partitionPath, final long processDefinitionKey) {
+    try {
+      return ok(getProcessImpl(partitionPath, processDefinitionKey));
+    } catch (final Exception e) {
+      return error(e);
+    }
+  }
+}

--- a/mcp-server/src/main/java/io/zell/zdb/mcp/util/PaginatedResult.java
+++ b/mcp-server/src/main/java/io/zell/zdb/mcp/util/PaginatedResult.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.mcp.util;
+
+import java.util.List;
+
+/** Helper for building MCP list-tool JSON envelopes from already-serialized JSON items. */
+public final class PaginatedResult {
+
+  private PaginatedResult() {}
+
+  /**
+   * Build a paginated JSON envelope from a list of items already encoded as JSON strings.
+   *
+   * <p>Output shape: {@code {"total_fetched":N,"offset":O,"limit":L,"has_more":B,"data":[...]}}.
+   *
+   * @param allItems all items collected from the backend (already JSON-encoded)
+   * @param offset the offset to start the page at
+   * @param limit the maximum number of items to include in the page
+   * @return a JSON object representing the page
+   */
+  public static String buildPageJson(
+      final List<String> allItems, final int offset, final int limit) {
+    final int size = allItems.size();
+    final int safeOffset = Math.max(0, offset);
+    final int safeLimit = Math.max(0, limit);
+    final int from = Math.min(safeOffset, size);
+    final int to = Math.min(safeOffset + safeLimit, size);
+    final List<String> page = allItems.subList(from, to);
+
+    final StringBuilder sb = new StringBuilder();
+    sb.append("{\"total_fetched\":").append(size);
+    sb.append(",\"offset\":").append(safeOffset);
+    sb.append(",\"limit\":").append(safeLimit);
+    sb.append(",\"has_more\":").append(to < size);
+    sb.append(",\"data\":[");
+    for (int i = 0; i < page.size(); i++) {
+      if (i > 0) {
+        sb.append(",");
+      }
+      sb.append(page.get(i));
+    }
+    sb.append("]}");
+    return sb.toString();
+  }
+}

--- a/mcp-server/src/main/java/io/zell/zdb/mcp/util/PathResolver.java
+++ b/mcp-server/src/main/java/io/zell/zdb/mcp/util/PathResolver.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.mcp.util;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+/** Utility for resolving the RocksDB runtime path inside a Zeebe partition directory. */
+public final class PathResolver {
+
+  private PathResolver() {}
+
+  /**
+   * Resolve the RocksDB runtime path for the given Zeebe partition directory. Falls back to the
+   * latest snapshot directory if no live runtime exists.
+   *
+   * @param partitionPath the partition directory (e.g. {@code <data>/raft-partition/partitions/1})
+   * @return the path to the runtime (or latest snapshot) directory
+   * @throws IllegalArgumentException if neither a runtime nor any snapshot is present
+   */
+  public static Path runtimePath(final String partitionPath) {
+    final Path partDir = Paths.get(partitionPath);
+    final Path runtime = partDir.resolve("runtime");
+    if (Files.isDirectory(runtime)) {
+      return runtime;
+    }
+
+    final Path snapshots = partDir.resolve("snapshots");
+    if (Files.isDirectory(snapshots)) {
+      try (Stream<Path> stream = Files.list(snapshots)) {
+        return stream
+            .filter(Files::isDirectory)
+            .max(Comparator.naturalOrder())
+            .orElseThrow(() -> new IllegalArgumentException("No snapshots found in " + snapshots));
+      } catch (final java.io.IOException e) {
+        throw new IllegalArgumentException("Failed to list snapshots directory: " + snapshots, e);
+      }
+    }
+
+    throw new IllegalArgumentException(
+        "No runtime or snapshots directory found in " + partitionPath);
+  }
+}

--- a/mcp-server/src/main/java/io/zell/zdb/mcp/util/ToolUtils.java
+++ b/mcp-server/src/main/java/io/zell/zdb/mcp/util/ToolUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.mcp.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import java.util.Map;
+
+/** Common utilities used by all MCP tool implementations. */
+public final class ToolUtils {
+
+  /** Shared Jackson ObjectMapper. Jackson 2 is on the classpath transitively. */
+  public static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private ToolUtils() {}
+
+  /** Build a successful tool result with the given JSON text payload. */
+  public static CallToolResult ok(final String json) {
+    return CallToolResult.builder().addTextContent(json).isError(false).build();
+  }
+
+  /** Build an error tool result wrapping the given exception's message. */
+  public static CallToolResult error(final Throwable t) {
+    final String message = t.getMessage() == null ? t.getClass().getSimpleName() : t.getMessage();
+    return CallToolResult.builder().addTextContent("Error: " + message).isError(true).build();
+  }
+
+  /** Build an error tool result with a custom message. */
+  public static CallToolResult error(final String message) {
+    return CallToolResult.builder().addTextContent("Error: " + message).isError(true).build();
+  }
+
+  /** Read a required String argument; throws if missing or wrong type. */
+  public static String requiredString(final Map<String, Object> args, final String key) {
+    final Object value = args == null ? null : args.get(key);
+    if (value == null) {
+      throw new IllegalArgumentException("Missing required argument: " + key);
+    }
+    if (!(value instanceof String s)) {
+      throw new IllegalArgumentException("Argument '" + key + "' must be a string");
+    }
+    if (s.isEmpty()) {
+      throw new IllegalArgumentException("Argument '" + key + "' must not be empty");
+    }
+    return s;
+  }
+
+  /** Read an optional String argument. Returns null when absent or empty. */
+  public static String optionalString(final Map<String, Object> args, final String key) {
+    final Object value = args == null ? null : args.get(key);
+    if (value == null) {
+      return null;
+    }
+    if (!(value instanceof String s)) {
+      throw new IllegalArgumentException("Argument '" + key + "' must be a string");
+    }
+    return s.isEmpty() ? null : s;
+  }
+
+  /** Read a required integer argument as long; throws if missing. */
+  public static long requiredLong(final Map<String, Object> args, final String key) {
+    final Object value = args == null ? null : args.get(key);
+    if (value == null) {
+      throw new IllegalArgumentException("Missing required argument: " + key);
+    }
+    if (!(value instanceof Number n)) {
+      throw new IllegalArgumentException("Argument '" + key + "' must be a number");
+    }
+    return n.longValue();
+  }
+
+  /** Read an optional Long argument; returns null when absent. */
+  public static Long optionalLong(final Map<String, Object> args, final String key) {
+    final Object value = args == null ? null : args.get(key);
+    if (value == null) {
+      return null;
+    }
+    if (!(value instanceof Number n)) {
+      throw new IllegalArgumentException("Argument '" + key + "' must be a number");
+    }
+    return n.longValue();
+  }
+
+  /** Read an optional integer argument with a default value. */
+  public static int intOrDefault(
+      final Map<String, Object> args, final String key, final int defaultValue) {
+    final Object value = args == null ? null : args.get(key);
+    if (value == null) {
+      return defaultValue;
+    }
+    if (!(value instanceof Number n)) {
+      throw new IllegalArgumentException("Argument '" + key + "' must be a number");
+    }
+    return n.intValue();
+  }
+}

--- a/mcp-server/src/test/java/io/zell/zdb/mcp/ZdbMcpToolsTest.java
+++ b/mcp-server/src/test/java/io/zell/zdb/mcp/ZdbMcpToolsTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.zeebe.containers.ZeebeContainer;
+import io.zell.zdb.mcp.tools.IncidentTools;
+import io.zell.zdb.mcp.tools.PartitionTools;
+import io.zell.zdb.mcp.tools.ProcessInstanceTools;
+import io.zell.zdb.mcp.tools.ProcessTools;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public class ZdbMcpToolsTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZdbMcpToolsTest.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final DockerImageName DOCKER_IMAGE =
+      DockerImageName.parse("camunda/camunda:8.8.0");
+
+  private static final String CONTAINER_DATA_PATH = "/usr/local/camunda/data/";
+
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess("mcp-process")
+          .startEvent()
+          .serviceTask("incidentTask")
+          .zeebeJobType("incidentTask")
+          .zeebeJobRetriesExpression("=foo") // causes incident
+          .endEvent()
+          .done();
+
+  private static final File TEMP_DIR = newTmpFolder();
+
+  static {
+    if (!TEMP_DIR.mkdirs() && !TEMP_DIR.isDirectory()) {
+      throw new IllegalStateException("Could not create temp dir " + TEMP_DIR);
+    }
+  }
+
+  /** A standalone Zeebe container that produces partition data into TEMP_DIR. */
+  @Container
+  public static ZeebeContainer zeebeContainer =
+      new ZeebeContainer(DOCKER_IMAGE)
+          .withCreateContainerCmdModifier(cmd -> cmd.withUser(getRunAsUser()))
+          .withEnv("ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL", "false")
+          .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", "none")
+          .withEnv("SPRING_PROFILES_ACTIVE", "broker,standalone")
+          .withLogConsumer(new Slf4jLogConsumer(LOGGER))
+          .withFileSystemBind(TEMP_DIR.getPath(), CONTAINER_DATA_PATH, BindMode.READ_WRITE);
+
+  private static Path copiedDataPath;
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    createWorkload(zeebeContainer.getExternalGatewayAddress());
+
+    // Copy data into a temp dir so we can read it after the container stops touching files.
+    copiedDataPath = Files.createTempDirectory("zdb-mcp-test-");
+    copyDirectory(TEMP_DIR.toPath(), copiedDataPath);
+  }
+
+  @AfterAll
+  public static void cleanup() throws IOException {
+    deleteRecursively(TEMP_DIR.toPath());
+    if (copiedDataPath != null) {
+      deleteRecursively(copiedDataPath);
+    }
+  }
+
+  @Test
+  public void shouldListPartitions() throws Exception {
+    // when
+    final CallToolResult result =
+        PartitionTools.listPartitionsCall(copiedDataPath.toAbsolutePath().toString());
+
+    // then
+    assertThat(result.isError()).isFalse();
+    final JsonNode json = parseTextContent(result);
+    assertThat(json.get("exists").asBoolean()).isTrue();
+    final JsonNode partitions = json.get("partitions");
+    assertThat(partitions.isArray()).isTrue();
+    assertThat(partitions.size()).isGreaterThanOrEqualTo(1);
+    final JsonNode first = partitions.get(0);
+    assertThat(first.get("id").asInt()).isEqualTo(1);
+    assertThat(first.get("partition_path").asText()).contains("partitions");
+  }
+
+  @Test
+  public void shouldGetPartitionStatus() throws Exception {
+    // given
+    final String partitionPath = firstPartitionPath();
+
+    // when
+    final CallToolResult result = PartitionTools.getPartitionStatusCall(partitionPath);
+
+    // then
+    assertThat(result.isError()).isFalse();
+    final JsonNode json = parseTextContent(result);
+    assertThat(json.has("log")).isTrue();
+    assertThat(json.has("raft")).isTrue();
+    final JsonNode log = json.get("log");
+    assertThat(log.has("highestIndex")).isTrue();
+    assertThat(log.has("highestTerm")).isTrue();
+    final JsonNode raft = json.get("raft");
+    assertThat(raft.has("meta")).isTrue();
+    assertThat(raft.has("config")).isTrue();
+  }
+
+  @Test
+  public void shouldListProcessInstances() throws Exception {
+    // given
+    final String partitionPath = firstPartitionPath();
+
+    // when
+    final CallToolResult result =
+        ProcessInstanceTools.listProcessInstancesCall(partitionPath, null, null, 0, 50);
+
+    // then
+    assertThat(result.isError()).isFalse();
+    final JsonNode json = parseTextContent(result);
+    assertThat(json.has("data")).isTrue();
+    assertThat(json.get("data").isArray()).isTrue();
+    assertThat(json.get("total_fetched").asInt()).isGreaterThanOrEqualTo(1);
+  }
+
+  @Test
+  public void shouldListIncidents() throws Exception {
+    // given
+    final String partitionPath = firstPartitionPath();
+
+    // when
+    final CallToolResult result =
+        IncidentTools.listIncidentsCall(partitionPath, null, null, null, 0, 50);
+
+    // then
+    assertThat(result.isError()).isFalse();
+    final JsonNode json = parseTextContent(result);
+    assertThat(json.has("data")).isTrue();
+    assertThat(json.get("data").isArray()).isTrue();
+    // We expect at least one incident from the workload (job retries expression).
+    assertThat(json.get("total_fetched").asInt()).isGreaterThanOrEqualTo(1);
+  }
+
+  @Test
+  public void shouldListProcesses() throws Exception {
+    // given
+    final String partitionPath = firstPartitionPath();
+
+    // when
+    final CallToolResult result = ProcessTools.listProcessesCall(partitionPath, 0, 50);
+
+    // then
+    assertThat(result.isError()).isFalse();
+    final JsonNode json = parseTextContent(result);
+    assertThat(json.has("data")).isTrue();
+    assertThat(json.get("total_fetched").asInt()).isGreaterThanOrEqualTo(1);
+  }
+
+  @Test
+  public void shouldReturnErrorForInvalidPath() {
+    final CallToolResult result =
+        PartitionTools.getPartitionStatusCall("/non/existent/path-zdb-mcp");
+    assertThat(result.isError()).isTrue();
+    assertThat(textOf(result)).startsWith("Error:");
+  }
+
+  // -- helpers ---------------------------------------------------------------------------
+
+  private static String firstPartitionPath() throws Exception {
+    final CallToolResult result =
+        PartitionTools.listPartitionsCall(copiedDataPath.toAbsolutePath().toString());
+    final JsonNode json = parseTextContent(result);
+    return json.get("partitions").get(0).get("partition_path").asText();
+  }
+
+  private static JsonNode parseTextContent(final CallToolResult result) throws IOException {
+    return OBJECT_MAPPER.readTree(textOf(result));
+  }
+
+  private static String textOf(final CallToolResult result) {
+    final TextContent text = (TextContent) result.content().get(0);
+    return text.text();
+  }
+
+  private static void createWorkload(final String gatewayAddress) {
+    try (ZeebeClient client =
+        ZeebeClient.newClientBuilder().gatewayAddress(gatewayAddress).usePlaintext().build()) {
+
+      final DeploymentEvent deployment =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(PROCESS, "mcp-process.bpmn")
+              .send()
+              .join();
+      assertThat(deployment.getProcesses()).hasSize(1);
+
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId("mcp-process")
+          .latestVersion()
+          .variables(Map.of("foo", "not-a-number"))
+          .send()
+          .join();
+
+      // Allow the broker time to materialise the job + create the incident.
+      try {
+        Thread.sleep(2000L);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  private static void copyDirectory(final Path source, final Path target) throws IOException {
+    try (Stream<Path> walk = Files.walk(source)) {
+      walk.forEach(
+          path -> {
+            try {
+              final Path dst = target.resolve(source.relativize(path).toString());
+              if (Files.isDirectory(path)) {
+                Files.createDirectories(dst);
+              } else {
+                Files.createDirectories(dst.getParent());
+                Files.copy(path, dst, StandardCopyOption.REPLACE_EXISTING);
+              }
+            } catch (final IOException e) {
+              throw new UncheckedIOException(e);
+            }
+          });
+    }
+  }
+
+  private static void deleteRecursively(final Path path) throws IOException {
+    if (!Files.exists(path)) {
+      return;
+    }
+    try (Stream<Path> walk = Files.walk(path)) {
+      walk.sorted((a, b) -> b.getNameCount() - a.getNameCount())
+          .forEach(
+              p -> {
+                try {
+                  Files.deleteIfExists(p);
+                } catch (final IOException ignored) {
+                  // best-effort cleanup
+                }
+              });
+    }
+  }
+
+  private static File newTmpFolder() {
+    return new File(
+        "/tmp/",
+        "zdb-mcp-test-"
+            + ZdbMcpToolsTest.class.getName()
+            + "-"
+            + ThreadLocalRandom.current().nextLong());
+  }
+
+  private static String getRunAsUser() {
+    return execCommand("id -u") + ":" + execCommand("id -g");
+  }
+
+  private static String execCommand(final String command) {
+    try {
+      final Process process = Runtime.getRuntime().exec(command);
+      try (var reader =
+          new java.io.BufferedReader(new java.io.InputStreamReader(process.getInputStream()))) {
+        return reader.readLine();
+      }
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
         <module>backend</module>
         <module>cli</module>
         <module>frontend</module>
+        <module>mcp-server</module>
     </modules>
 
     <build>

--- a/zdb-mcp
+++ b/zdb-mcp
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Starts the zdb MCP server over stdio.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+JAR="$SCRIPT_DIR/mcp-server/target/zdb-mcp-jar-with-dependencies.jar"
+if [ ! -f "$JAR" ]; then
+  echo "ERROR: zdb-mcp.jar not found at $JAR. Run 'mvn package -pl mcp-server -am -DskipTests' first." >&2
+  exit 1
+fi
+exec java -jar "$JAR" "$@"


### PR DESCRIPTION
## Summary

Adds a new `mcp-server` module that exposes zdb's existing backend readers
as a Model Context Protocol (MCP) server, so an LLM (e.g. Claude Code) can
inspect a customer's Zeebe partition data locally without shelling out to
the CLI.

The server speaks MCP over stdio and ships 12 read-only tools covering:

- **Partitions** — discover partition dirs, combined log+raft status
- **Processes & instances** — list/get deployed processes and running instances
- **Incidents** — list/get active incidents, filterable by error type, BPMN
  process id, or process definition key
- **Raft log** — status plus search by position, index, or range
- **RocksDB** — column family row counts

All list endpoints use a paginated envelope
(`{total_fetched, offset, limit, has_more, data}`). State tools resolve the
runtime path internally and fall back to the latest snapshot when no live
runtime exists.

Build: `mvn package -pl mcp-server -am -DskipTests`
Run: `./zdb-mcp`

Wire-up for Claude Code is documented in `mcp-server/README.md` and
`CLAUDE.md`.

